### PR TITLE
Automatically removes old Github Packages

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -19,45 +19,59 @@ jobs:
         run: |
           echo "Checking versions for the package ${{ matrix.package }}"
 
-          # Lister les versions du package et afficher la réponse pour débogage
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions"
-
-      - name: List package versions ${{ matrix.package }}
+      - name: List package versions ${{ matrix.package }} (with pagination)
         id: list-versions
         run: |
           echo "Extracting version IDs for the package ${{ matrix.package }}"
 
-          # Lister les versions du package pour l'utilisateur et vérifier qu'elles contiennent un 'id'
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github+json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions" \
-          | jq -r '.[] | select(.id != null) | .id' > all_ids.txt
+          # Initialise un fichier pour stocker tous les IDs
+          > all_ids.txt
+
+          # Boucle pour récupérer toutes les pages de résultats de l'API
+          page=1
+          while true; do
+            response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions?page=$page&per_page=100")
+
+            # Vérifie s'il y a des versions sur cette page
+            if [ "$(echo $response | jq -r '. | length')" -eq 0 ]; then
+              break
+            fi
+
+            # Extrait les IDs et les ajoute au fichier all_ids.txt
+            echo "$response" | jq -r '.[] | select(.id != null) | .id' >> all_ids.txt
+
+            page=$((page + 1))
+          done
 
       - name: Get the 10 most recent versions of the package ${{ matrix.package }}
         run: |
-          # Lister les 10 versions les plus récentes
+          # Liste les 10 versions les plus récentes
           curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions" \
-          | jq -r '.[0:10] | .[].id' > keep_ids.txt
+          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions?per_page=10" \
+          | jq -r '.[].id' > keep_ids.txt
 
       - name: Remove older versions of the package ${{ matrix.package }}
         run: |
-          # Identifier les versions à supprimer
-          grep -vxFf keep_ids.txt all_ids.txt > delete_ids.txt
+          # Identifie les versions à supprimer
+          grep -vxFf keep_ids.txt all_ids.txt > delete_ids.txt || true
 
-          # Boucle pour supprimer chaque ancienne version
-          while read -r version_id; do
-            echo "Removing version $version_id from package ${{ matrix.package }}"
+          # Vérifie s'il y a quelque chose à supprimer
+          if [ -s delete_ids.txt ]; then
+            # Boucle pour supprimer chaque ancienne version
+            while read -r version_id; do
+              echo "Removing version $version_id from package ${{ matrix.package }}"
 
-            # Supprime les versions
-            curl -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions/$version_id"
-          done < delete_ids.txt
+              # Supprime les versions
+              curl -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions/$version_id"
+            done < delete_ids.txt
+          else
+            echo "No old versions to delete for package ${{ matrix.package }}"
+          fi

--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -1,0 +1,63 @@
+name: Cleanup old GitHub Packages
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  cleanup-packages:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - taxdom-web
+          - taxdom-api
+
+    steps:
+      - name: Check API response for package ${{ matrix.package }}
+        id: check-api-response
+        run: |
+          echo "Checking versions for the package ${{ matrix.package }}"
+
+          # Lister les versions du package et afficher la réponse pour débogage
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions"
+
+      - name: List package versions ${{ matrix.package }}
+        id: list-versions
+        run: |
+          echo "Extracting version IDs for the package ${{ matrix.package }}"
+
+          # Lister les versions du package pour l'utilisateur et vérifier qu'elles contiennent un 'id'
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions" \
+          | jq -r '.[] | select(.id != null) | .id' > all_ids.txt
+
+      - name: Get the 10 most recent versions of the package ${{ matrix.package }}
+        run: |
+          # Lister les 10 versions les plus récentes
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions" \
+          | jq -r '.[0:10] | .[].id' > keep_ids.txt
+
+      - name: Remove older versions of the package ${{ matrix.package }}
+        run: |
+          # Identifier les versions à supprimer
+          grep -vxFf keep_ids.txt all_ids.txt > delete_ids.txt
+
+          # Boucle pour supprimer chaque ancienne version
+          while read -r version_id; do
+            echo "Removing version $version_id from package ${{ matrix.package }}"
+
+            # Supprime les versions
+            curl -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/users/${{ github.actor }}/packages/container/${{ matrix.package }}/versions/$version_id"
+          done < delete_ids.txt


### PR DESCRIPTION
Introduces a monthly scheduled GitHub Actions workflow to clean up older versions of Docker packages `taxdom-web` and `taxdom-api`, keeping only the 10 most recent. The workflow queries the GitHub API to retrieve all package versions, identifies which versions to keep, then removes older versions via `DELETE` requests.

The GitHub API paging the results in increments of 20, a loop allows all old versions to be mapped even if they exceed the number of elements available via an API call.