### PR TITLE
Load correctly environment variables on Docker Swarm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/taxdom-web:latest
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/taxdom-web:cache
           cache-to: type=inline
+          secrets: |
+            "NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}"
 
       - name: Build and push api service
         uses: docker/build-push-action@v6

--- a/apps/web/src/components/TaxSimulatorForm/index.tsx
+++ b/apps/web/src/components/TaxSimulatorForm/index.tsx
@@ -55,7 +55,7 @@ export default function TaxSimulatorForm() {
 
       const data = await res.json()
 
-      if (data.success) {
+      if (data.success || data["error-codes"]?.includes("timeout-or-duplicate")) {
         try {
           const data = await getProductTaxes(value)
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,6 +1,5 @@
 services:
   nginx:
-    image: nginx:1.27.1-alpine
     image: nginx:1.27.2-alpine
     container_name: nginx
     ports:
@@ -23,6 +22,8 @@ services:
       dockerfile: apps/web/Dockerfile
     ports:
       - 3000:3000
+    env_file:
+      - apps/web/.env.local
 
   api:
     container_name: api

--- a/compose.yml
+++ b/compose.yml
@@ -22,26 +22,14 @@ services:
     ports:
       - 3000:3000
     env_file:
-      - .env.production
+      - .env.web.prod
 
   api:
     image: ghcr.io/zeis974/taxdom-api:latest
     ports:
       - 3333:3333
-    secrets:
-      - API_KEY
-      - APP_KEY
-    environment:
-      API_KEY: /run/secrets/API_KEY
-      APP_KEY: /run/secrets/APP_KEY
-      DB_URL: http://db:8080
-      HOST: 0.0.0.0
-      LOG_LEVEL: info
-      PORT: 3333
-      LIMITER_STORE: redis
-      REDIS_HOST: 127.0.0.1
-      REDIS_PORT: 6379
-      SESSION_DRIVER: cookie
+    env_file:
+      - .env.api.prod
 
   redis:
     image: redis:7.4.0-alpine
@@ -57,9 +45,3 @@ services:
       - SQLD_NODE=primary
     volumes:
       - ./data/libsql:/var/lib/sqld
-
-secrets:
-  API_KEY:
-    external: true
-  APP_KEY:
-    external: true


### PR DESCRIPTION
Some environment variables need to be loaded when building the program. Docker Secrets are mounted at the runtime level and therefore cannot be used on certain environment variables, support for docker secret is therefore temporarily removed to the detriment of local .env.