### PR TITLE
fix(action): no permission for delete packages

### DIFF
--- a/.github/workflows/delete-old-packages.yml
+++ b/.github/workflows/delete-old-packages.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 1 * *"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   cleanup-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The token provided automatically when executing the action did not have the appropriate rights to delete the packages.

ref: https://github.com/zeis974/TaxDOM/actions/runs/11622712186/workflow