### PR TITLE
Improve libsql connection

### DIFF
--- a/apps/api/config/database.ts
+++ b/apps/api/config/database.ts
@@ -1,12 +1,8 @@
-import env from "#start/env"
-
-import { createClient } from "@libsql/client"
-import { drizzle } from "drizzle-orm/libsql"
-
 import * as schema from "#database/schema"
 
-const client = createClient({
-  url: env.get("DB_URL"),
-})
+import env from "#start/env"
+import { drizzle } from "drizzle-orm/libsql"
 
-export const db = drizzle(client, { schema })
+export const db = drizzle(env.get("DB_URL"), {
+  schema: schema,
+})

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "drizzle-kit"
 
 export default defineConfig({
+  dialect: "turso",
   schema: "./database/schema.ts",
   out: "./database/migrations",
-  dialect: "sqlite",
-  driver: "turso",
   dbCredentials: {
     url: process.env.DB_URL as string,
   },
+  breakpoints: true,
+  verbose: true,
 })

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,10 @@
     "build": "node ace build",
     "dev": "node ace serve --hmr",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push"
   },
   "imports": {
     "#controllers/*": "./app/controllers/*.js",
@@ -38,7 +41,7 @@
     "@adonisjs/session": "7.5.0",
     "@libsql/client": "0.14.0",
     "@vinejs/vine": "2.1.0",
-    "drizzle-orm": "0.33.0",
+    "drizzle-orm": "0.36.0",
     "luxon": "3.5.0",
     "reflect-metadata": "0.2.2"
   },
@@ -49,7 +52,7 @@
     "@swc/core": "1.7.39",
     "@types/luxon": "^3.4.2",
     "@types/node": "^20.14.12",
-    "drizzle-kit": "0.24.2",
+    "drizzle-kit": "0.27.0",
     "eslint": "8.57.0",
     "hot-hook": "0.3.1",
     "pino-pretty": "11.3.0",


### PR DESCRIPTION
Update drizzle dependencies to better handle `libsql`, due to the design of libsql which extends the functionality of sqlite