### PR TITLE
feat: separate `select` UI and logic

### DIFF
--- a/apps/web/src/components/Forms/Checkbox/Checkbox.styled.tsx
+++ b/apps/web/src/components/Forms/Checkbox/Checkbox.styled.tsx
@@ -1,0 +1,19 @@
+import { styled } from "@/panda/jsx"
+
+export const Container = styled.div`
+  margin-bottom: 10px;
+  user-select: none;
+
+  &:has(input[aria-disabled="true"]),
+  &:has(input[disabled="true"]) {
+    opacity: 0.5;
+  }
+
+  & input {
+    margin-right: 10px;
+  }
+
+  & span {
+    line-height: 1;
+  }
+`

--- a/apps/web/src/components/Forms/Checkbox/index.tsx
+++ b/apps/web/src/components/Forms/Checkbox/index.tsx
@@ -1,0 +1,52 @@
+import type { CheckboxProps } from "@/components/Forms/types"
+
+import { formOpts, useFieldContext, withForm } from "@/hooks/form"
+
+import { Container } from "./Checkbox.styled"
+
+export default function CheckboxField({ disabled, name, label }: CheckboxProps) {
+  const field = useFieldContext<boolean>()
+
+  return (
+    <Container>
+      <label htmlFor={name}>
+        <input
+          id={field.name}
+          name={field.name}
+          type="checkbox"
+          checked={!!field.state.value}
+          onBlur={() => {
+            field.handleBlur()
+          }}
+          onChange={(e) => {
+            field.handleChange(e.target.checked)
+          }}
+          aria-disabled={disabled}
+          disabled={disabled}
+        />
+        <span>{label}</span>
+      </label>
+    </Container>
+  )
+}
+
+export const Checkbox = withForm({
+  ...formOpts,
+  props: {
+    disabled: false,
+    label: "",
+    name: "" as CheckboxProps["name"],
+  } as CheckboxProps,
+  render: ({ form, disabled, label, name }) => (
+    <form.AppField
+      name={name}
+      validators={{
+        onSubmit: ({ value }) => {
+          if (!value) return "Champs requis"
+        },
+      }}
+    >
+      {(field) => <field.CheckboxField {...{ disabled, label, name }} />}
+    </form.AppField>
+  ),
+})

--- a/apps/web/src/components/Forms/Input/Input.styled.tsx
+++ b/apps/web/src/components/Forms/Input/Input.styled.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@/panda/jsx"
 
-export const Container = styled.div`
+export const InputContainer = styled.div`
   display: flex;
   position: relative;
   flex-direction: column;
@@ -8,7 +8,7 @@ export const Container = styled.div`
   font-family: token(fonts.nativeFont);
 
   & > label {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     font-size: clamp(0.875rem, 0.8529rem + 0.0941vw, 1rem);
     font-weight: 600;
     user-select: none;

--- a/apps/web/src/components/Forms/Input/index.tsx
+++ b/apps/web/src/components/Forms/Input/index.tsx
@@ -1,16 +1,16 @@
-import type { InputProps } from "@/components/Forms/types"
-
-import { formOpts, useFieldContext, withForm } from "@/hooks/form"
 import { useStore } from "@tanstack/react-form"
 
-import { Container } from "./Input.styled"
+import type { InputProps } from "@/components/Forms/types"
+import { formOpts, useFieldContext, withForm } from "@/hooks/form"
+
+import { InputContainer } from "./Input.styled"
 
 export default function InputField({ name, label, placeholder, type = "text" }: InputProps) {
   const field = useFieldContext<string | number>()
   const errors = useStore(field.store, (state) => state.meta.errors)
 
   return (
-    <Container>
+    <InputContainer>
       <label htmlFor={name}>
         {label}{" "}
         {errors.map((error: string) => (
@@ -31,7 +31,7 @@ export default function InputField({ name, label, placeholder, type = "text" }: 
           field.handleChange(e.target.value)
         }}
       />
-    </Container>
+    </InputContainer>
   )
 }
 

--- a/apps/web/src/components/Forms/Select/BaseSelect.tsx
+++ b/apps/web/src/components/Forms/Select/BaseSelect.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { AnimatePresence } from "motion/react"
+import * as m from "motion/react-m"
+import { useRef, useState } from "react"
+
+import { InputContainer } from "@/components/Forms/Input/Input.styled"
+import { LoadingCircle, OptionContainer } from "./Select.styled"
+
+export interface BaseOption {
+  name: string
+  available?: boolean
+  value?: string
+}
+
+export interface BaseSelectProps {
+  id?: string
+  name?: string
+  label: string
+  placeholder?: string
+  options: BaseOption[]
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  onFocus?: () => void
+  loading?: boolean
+  errors?: string[]
+  disabled?: boolean
+  required?: boolean
+}
+
+interface OptionsListProps {
+  options: BaseOption[]
+  value: string
+  onSelect: (value: string) => void
+  selectedIndex: number
+  setSelectedIndex: (index: number) => void
+  onWatch?: (value: string) => void
+}
+
+const OptionsList = ({
+  options,
+  value,
+  onSelect,
+  selectedIndex,
+  setSelectedIndex,
+  onWatch,
+}: OptionsListProps) => {
+  const parentRef = useRef<HTMLUListElement>(null)
+  const itemHeight = 35
+  const maxVisibleItems = 6
+
+  const filteredOptions = options.filter((option) => {
+    const lowerCaseValue = value.toLowerCase()
+    const exactMatchFound =
+      lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
+    const lowerCaseOption = option.name.toLowerCase()
+    return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
+  })
+
+  const shouldVirtualize = filteredOptions.length > maxVisibleItems
+
+  const containerHeight = shouldVirtualize
+    ? maxVisibleItems * itemHeight
+    : filteredOptions.length * itemHeight
+
+  const virtualizer = useVirtualizer({
+    count: filteredOptions.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => itemHeight,
+    overscan: 5,
+  })
+
+  if (filteredOptions.length === 0) return null
+
+  return (
+    <OptionContainer
+      ref={parentRef}
+      aria-label="Liste déroulante"
+      style={{
+        height: `${containerHeight}px`,
+        overflow: shouldVirtualize ? "auto" : "hidden",
+      }}
+    >
+      {shouldVirtualize ? (
+        <div
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            width: "100%",
+            position: "relative",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const option = filteredOptions[virtualItem.index]
+            return (
+              <li
+                key={option.name}
+                data-selected={virtualItem.index === selectedIndex}
+                data-available={option.available}
+                onClick={() => onSelect(option.value || option.name)}
+                onKeyUp={() => onSelect(option.value || option.name)}
+                onMouseEnter={() => {
+                  onWatch?.(option.name)
+                  setSelectedIndex(virtualItem.index)
+                }}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  height: `${virtualItem.size}px`,
+                  transform: `translateY(${virtualItem.start}px)`,
+                }}
+              >
+                {option.name}
+              </li>
+            )
+          })}
+        </div>
+      ) : (
+        filteredOptions.map((option, index) => (
+          <li
+            key={option.name}
+            data-selected={index === selectedIndex}
+            data-available={option.available}
+            onClick={() => onSelect(option.value || option.name)}
+            onKeyUp={() => onSelect(option.value || option.name)}
+            onMouseEnter={() => {
+              onWatch?.(option.name)
+              setSelectedIndex(index)
+            }}
+            style={{
+              height: `${itemHeight}px`,
+              display: "flex",
+              alignItems: "center",
+              padding: "0 5px",
+            }}
+          >
+            {option.name}
+          </li>
+        ))
+      )}
+    </OptionContainer>
+  )
+}
+
+export default function BaseSelect({
+  id,
+  name,
+  label,
+  placeholder,
+  options,
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  loading = false,
+  errors = [],
+  disabled = false,
+  required = false,
+}: BaseSelectProps) {
+  const selectedIndexRef = useRef(0)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [show, setShow] = useState(false)
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (options.length === 0) return
+
+    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+      e.preventDefault()
+      setSelectedIndex((prevIndex) => {
+        const filteredOptions = options.filter((option) => {
+          const lowerCaseValue = value.toLowerCase()
+          const exactMatchFound =
+            lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
+          const lowerCaseOption = option.name.toLowerCase()
+          return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
+        })
+
+        const newIndex =
+          e.key === "ArrowUp"
+            ? (prevIndex - 1 + filteredOptions.length) % filteredOptions.length
+            : (prevIndex + 1) % filteredOptions.length
+        selectedIndexRef.current = newIndex
+        return newIndex
+      })
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const filteredOptions = options.filter((option) => {
+        const lowerCaseValue = value.toLowerCase()
+        const exactMatchFound =
+          lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
+        const lowerCaseOption = option.name.toLowerCase()
+        return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
+      })
+
+      const selectedOption = filteredOptions[selectedIndexRef.current]
+      if (selectedOption) {
+        onChange(selectedOption.value || selectedOption.name)
+        setShow(false)
+      }
+    }
+
+    if (e.key === "Escape") {
+      setShow(false)
+    }
+  }
+
+  return (
+    <InputContainer>
+      <label htmlFor={id || name}>
+        {label}
+        {required && " *"}
+        {errors.length > 0 && <span> {errors.join(", ")}</span>}
+      </label>
+      <input
+        id={id || name}
+        name={name}
+        autoComplete="off"
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={() => {
+          setShow(false)
+          onBlur?.()
+        }}
+        onFocus={() => {
+          setShow(true)
+          onFocus?.()
+        }}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        required={required}
+      />
+      {loading && <LoadingCircle />}
+      <AnimatePresence>
+        {options.length > 0 && show && (
+          <m.div
+            style={{ zIndex: 1, height: "100%" }}
+            initial={{ translateY: "-5px", opacity: 0 }}
+            animate={{ translateY: "0", opacity: 1 }}
+            exit={{ translateY: "5px", opacity: 0 }}
+          >
+            <OptionsList
+              options={options}
+              value={value}
+              onSelect={(selectedValue) => {
+                onChange(selectedValue)
+                setShow(false)
+              }}
+              selectedIndex={selectedIndex}
+              setSelectedIndex={setSelectedIndex}
+            />
+          </m.div>
+        )}
+      </AnimatePresence>
+    </InputContainer>
+  )
+}

--- a/apps/web/src/components/Forms/Select/index.tsx
+++ b/apps/web/src/components/Forms/Select/index.tsx
@@ -1,18 +1,14 @@
 "use client"
 
-import type { OptionsProps, SelectProps } from "@/components/Forms/types"
-import type { TaxSimulatorFormLabel } from "@/components/services/TaxSimulator/types"
-import { useVirtualizer } from "@tanstack/react-virtual"
+import { useState } from "react"
 
-import { AnimatePresence } from "motion/react"
-import * as m from "motion/react-m"
-import { useRef, useState } from "react"
-
-import { searchProducts } from "@/actions/searchProducts"
+import { searchProducts } from "@/actions/products/searchProducts"
 import { formOpts, useFieldContext, withForm } from "@/hooks/form"
 
-import { Container } from "@/components/Forms/Input/Input.styled"
-import { LoadingCircle, OptionContainer } from "./Select.styled"
+import type { TaxSimulatorFormLabel } from "@/components/services/TaxSimulator/types"
+import type { SelectProps } from "@/components/Forms/types"
+
+import BaseSelect from "./BaseSelect"
 
 export default function SelectField({
   label,
@@ -22,189 +18,28 @@ export default function SelectField({
   loading,
   placeholder,
 }: SelectProps) {
-  const selectedIndexRef = useRef(0)
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const [show, setShow] = useState(false)
-
   const field = useFieldContext<string>()
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (staticOptions.length === 0) return
-
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-      setSelectedIndex((prevIndex) => {
-        const newIndex =
-          e.key === "ArrowUp"
-            ? (prevIndex - 1 + staticOptions.length) % staticOptions.length
-            : (prevIndex + 1) % staticOptions.length
-        selectedIndexRef.current = newIndex
-        return newIndex
-      })
-    }
-  }
-
   return (
-    <Container>
-      <label htmlFor={field.name}>
-        {label}{" "}
-        {field.state.meta.errors.length > 0 && <span>{field.state.meta.errors.join(", ")}</span>}
-      </label>
-      <input
-        id={field.name}
-        autoComplete="off"
-        name={field.name}
-        onChange={(e) => field.handleChange(e.target.value)}
-        onBlur={() => {
-          setShow(false)
-          field.handleBlur()
-        }}
-        onFocus={() => {
-          setShow(true)
-          actions?.handleOnFocus?.(field.name as TaxSimulatorFormLabel)
-        }}
-        onKeyDown={(e) => {
-          handleKeyDown(e)
-          const selectedValue = staticOptions[selectedIndexRef.current]
-
-          if (selectedValue) {
-            watch?.(selectedValue.name)
-          }
-
-          if (e.key === "Enter" && selectedValue) {
-            e.preventDefault()
-            field.handleChange(selectedValue.name)
-          }
-        }}
-        placeholder={placeholder}
-        value={field.state.value}
-      />
-      {loading && <LoadingCircle />}
-      <AnimatePresence>
-        {staticOptions.length > 0 && show && (
-          <m.div
-            style={{ zIndex: 1, height: "100%" }}
-            initial={{ translateY: "-5px", opacity: 0 }}
-            animate={{ translateY: "0", opacity: 1 }}
-            exit={{ translateY: "5px", opacity: 0 }}
-          >
-            <Options
-              type={actions?.dynamic ? "dynamic" : "static"}
-              options={staticOptions}
-              field={field}
-              selectedIndex={selectedIndex}
-              setSelectedIndex={setSelectedIndex}
-              watch={watch}
-            />
-          </m.div>
-        )}
-      </AnimatePresence>
-    </Container>
-  )
-}
-
-const Options = ({
-  field,
-  options,
-  selectedIndex,
-  setSelectedIndex,
-  type,
-  watch,
-}: OptionsProps) => {
-  if (!Array.isArray(options) || (options.length === 0 && type === "dynamic")) return null
-
-  const filteredOptions = options.filter((option) => {
-    const lowerCaseValue = field.state.value.toLowerCase()
-    const exactMatchFound =
-      lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-    const lowerCaseOption = option.name.toLowerCase()
-    return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-  })
-
-  const parentRef = useRef<HTMLUListElement>(null)
-  const itemHeight = 35
-  const maxVisibleItems = 6
-  const shouldVirtualize = filteredOptions.length > maxVisibleItems
-
-  const containerHeight = shouldVirtualize
-    ? maxVisibleItems * itemHeight
-    : filteredOptions.length * itemHeight
-
-  const virtualizer = useVirtualizer({
-    count: filteredOptions.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => itemHeight,
-    overscan: 5,
-  })
-
-  return filteredOptions.length > 0 ? (
-    <OptionContainer
-      ref={parentRef}
-      aria-label="Liste déroulante"
-      style={{
-        height: `${containerHeight}px`,
-        overflow: shouldVirtualize ? "auto" : "hidden",
+    <BaseSelect
+      id={field.name}
+      name={field.name}
+      label={label}
+      placeholder={placeholder}
+      options={staticOptions}
+      value={field.state.value}
+      onChange={(value) => {
+        field.handleChange(value)
+        watch?.(value)
       }}
-    >
-      {shouldVirtualize ? (
-        <div
-          style={{
-            height: `${virtualizer.getTotalSize()}px`,
-            width: "100%",
-            position: "relative",
-          }}
-        >
-          {virtualizer.getVirtualItems().map((virtualItem) => {
-            const option = filteredOptions[virtualItem.index]
-            return (
-              <li
-                key={option.name}
-                data-selected={virtualItem.index === selectedIndex}
-                data-available={option.available}
-                onClick={() => field.handleChange(option.name)}
-                onKeyUp={() => field.handleChange(option.name)}
-                onMouseEnter={() => {
-                  watch?.(option.name)
-                  setSelectedIndex?.(virtualItem.index)
-                }}
-                style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-              >
-                {option.name}
-              </li>
-            )
-          })}
-        </div>
-      ) : (
-        filteredOptions.map((option, index) => (
-          <li
-            key={option.name}
-            data-selected={index === selectedIndex}
-            data-available={option.available}
-            onClick={() => field.handleChange(option.name)}
-            onKeyUp={() => field.handleChange(option.name)}
-            onMouseEnter={() => {
-              watch?.(option.name)
-              setSelectedIndex?.(index)
-            }}
-            style={{
-              height: `${itemHeight}px`,
-              display: "flex",
-              alignItems: "center",
-              padding: "0 5px",
-            }}
-          >
-            {option.name}
-          </li>
-        ))
-      )}
-    </OptionContainer>
-  ) : null
+      onBlur={() => field.handleBlur()}
+      onFocus={() => {
+        actions?.handleOnFocus?.(field.name as TaxSimulatorFormLabel)
+      }}
+      loading={loading}
+      errors={field.state.meta.errors}
+    />
+  )
 }
 
 export const Select = withForm({
@@ -223,7 +58,7 @@ export const Select = withForm({
       )
     }
 
-    const [options, setOptions] = useState<OptionsProps["options"]>(staticOptions || [])
+    const [options, setOptions] = useState(staticOptions || [])
     const [loading, setLoading] = useState(false)
 
     return (
@@ -237,7 +72,6 @@ export const Select = withForm({
               const data = await searchProducts(value as string)
               setLoading(false)
               setOptions(data)
-              return data.error === "No product found" ? "Aucun produit trouvé" : undefined
             }
           },
           onChange: ({ value }) => {
@@ -265,7 +99,11 @@ export const Select = withForm({
       >
         {(field) => (
           <field.SelectField
-            {...{ name, label, actions, placeholder, loading }}
+            name={name}
+            label={label}
+            actions={actions}
+            placeholder={placeholder}
+            loading={loading}
             staticOptions={options}
           />
         )}

--- a/apps/web/src/components/Forms/types.ts
+++ b/apps/web/src/components/Forms/types.ts
@@ -1,13 +1,21 @@
-import type { FieldApi } from "@tanstack/react-form"
+import { z } from "zod"
 
 import type { ParcelSimulatorFormLabel } from "@/components/services/ParcelSimulator/types"
 import type { TaxSimulatorFormLabel } from "@/components/services/TaxSimulator/types"
 
-import { z } from "zod"
+export type FormLabel = ParcelSimulatorFormLabel | TaxSimulatorFormLabel
+
+const CheckboxSchema = z.object({
+  label: z.string(),
+  name: z.custom<FormLabel>(),
+  disabled: z.boolean().optional(),
+})
+
+export type CheckboxProps = z.infer<typeof CheckboxSchema>
 
 const InputSchema = z.object({
   label: z.string(),
-  name: z.custom<ParcelSimulatorFormLabel | TaxSimulatorFormLabel>(),
+  name: z.custom<FormLabel>(),
   type: z.enum(["text", "number"]).optional(),
   placeholder: z.string(),
 })
@@ -16,55 +24,16 @@ export type InputProps = z.infer<typeof InputSchema>
 
 const RadioSchema = z.object({
   label: z.string(),
-  name: z.custom<ParcelSimulatorFormLabel | TaxSimulatorFormLabel>(),
+  name: z.custom<FormLabel>(),
   options: z.array(z.string()),
   disabled: z.boolean().optional(),
 })
 
 export type RadioProps = z.infer<typeof RadioSchema>
 
-const OptionSchema = z.object({
-  field:
-    z.custom<
-      FieldApi<
-        any,
-        string,
-        string,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any,
-        any
-      >
-    >(),
-  options: z.array(
-    z.object({
-      name: z.string(),
-      available: z.boolean().optional(),
-    }),
-  ),
-  selectedIndex: z.number(),
-  setSelectedIndex: z.custom<React.Dispatch<React.SetStateAction<number>>>().optional(),
-  type: z.enum(["dynamic", "static"]),
-  watch: z.function().optional(),
-})
-
-export type OptionsProps = z.infer<typeof OptionSchema>
-
 const SelectSchema = z.object({
   label: z.string(),
-  name: z.custom<ParcelSimulatorFormLabel | TaxSimulatorFormLabel>(),
+  name: z.custom<FormLabel>(),
   placeholder: z.string(),
   staticOptions: z
     .array(


### PR DESCRIPTION
Extract Select component UI logic into BaseSelect for framework-agnostic reusability. Separates presentation layer from TanStack Form integration, allowing styled selects to be used in any component.