### PR TITLE
feat: rework dynamic select

### DIFF
--- a/apps/web/src/components/Forms/Input/Input.styled.tsx
+++ b/apps/web/src/components/Forms/Input/Input.styled.tsx
@@ -38,6 +38,11 @@ export const InputContainer = styled.div`
     &:focus {
       border: 2px solid #3498db;
     }
+
+    &[disabled="true"],
+    &[aria-disabled="true"] {
+      cursor: not-allowed;
+    }
   }
 
   & > input[type="number"] {

--- a/apps/web/src/components/Forms/Input/index.tsx
+++ b/apps/web/src/components/Forms/Input/index.tsx
@@ -5,7 +5,13 @@ import { formOpts, useFieldContext, withForm } from "@/hooks/form"
 
 import { InputContainer } from "./Input.styled"
 
-export default function InputField({ name, label, placeholder, type = "text" }: InputProps) {
+export default function InputField({
+  name,
+  label,
+  placeholder,
+  type = "text",
+  disabled = false,
+}: InputProps) {
   const field = useFieldContext<string | number>()
   const errors = useStore(field.store, (state) => state.meta.errors)
 
@@ -24,6 +30,8 @@ export default function InputField({ name, label, placeholder, type = "text" }: 
         name={field.name}
         type={type}
         value={field.state.value}
+        disabled={disabled}
+        aria-disabled={disabled}
         onBlur={() => {
           field.handleBlur()
         }}
@@ -42,8 +50,9 @@ export const Input = withForm({
     label: "",
     placeholder: "",
     type: "text",
+    disabled: false,
   } as InputProps,
-  render: ({ form, name, label, placeholder, type }) => (
+  render: ({ form, name, label, placeholder, type, disabled }) => (
     <form.AppField
       name={name}
       validators={{
@@ -52,7 +61,7 @@ export const Input = withForm({
         },
       }}
     >
-      {(field) => <field.InputField {...{ name, label, placeholder, type }} />}
+      {(field) => <field.InputField {...{ name, label, placeholder, type, disabled }} />}
     </form.AppField>
   ),
 })

--- a/apps/web/src/components/Forms/Select/index.tsx
+++ b/apps/web/src/components/Forms/Select/index.tsx
@@ -1,24 +1,49 @@
 "use client"
 
-import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
 
-import { searchProducts } from "@/actions/products/searchProducts"
 import { formOpts, useFieldContext, withForm } from "@/hooks/form"
 
-import type { TaxSimulatorFormLabel } from "@/components/services/TaxSimulator/types"
 import type { SelectProps } from "@/components/Forms/types"
-
 import BaseSelect from "./BaseSelect"
 
 export default function SelectField({
   label,
-  actions,
-  staticOptions = [],
-  watch,
+  options = [],
+  dynamic,
   loading,
   placeholder,
 }: SelectProps) {
   const field = useFieldContext<string>()
+  const currentValue = field.state.value || ""
+
+  const enabled = Boolean(dynamic && currentValue)
+
+  const { data: dynamicOptions = [], isFetching } = useQuery<
+    { name: string; value?: string }[],
+    Error
+  >({
+    queryKey: ["select-options", dynamic, currentValue],
+    queryFn: async () => {
+      const path = dynamic ?? ""
+      const url = path.startsWith("http") ? new URL(path) : new URL(path, window.location.origin)
+      url.searchParams.set("name", currentValue)
+      const res = await fetch(url.toString(), {
+        method: "GET",
+        headers: { "content-type": "application/json" },
+      })
+      if (!res.ok) throw new Error("Failed to fetch options")
+      return (await res.json()) as { name: string; value?: string }[]
+    },
+    enabled,
+    staleTime: 30_000,
+  })
+
+  const mergedOptions = useMemo(
+    () => (dynamic ? dynamicOptions : (options ?? [])),
+    [dynamic, dynamicOptions, options],
+  )
 
   return (
     <BaseSelect
@@ -26,17 +51,13 @@ export default function SelectField({
       name={field.name}
       label={label}
       placeholder={placeholder}
-      options={staticOptions}
-      value={field.state.value}
+      options={mergedOptions}
+      value={field.state.value ?? ""}
       onChange={(value) => {
         field.handleChange(value)
-        watch?.(value)
       }}
       onBlur={() => field.handleBlur()}
-      onFocus={() => {
-        actions?.handleOnFocus?.(field.name as TaxSimulatorFormLabel)
-      }}
-      loading={loading}
+      loading={loading || isFetching}
       errors={field.state.meta.errors}
     />
   )
@@ -48,18 +69,15 @@ export const Select = withForm({
     name: "" as SelectProps["name"],
     label: "",
     placeholder: "",
-    staticOptions: [],
-    actions: { dynamic: false },
+    options: [],
+    actions: {},
   } as SelectProps,
-  render: function Render({ form, name, label, staticOptions, placeholder, actions }) {
-    if ((staticOptions?.length ?? 0) > 0 && actions?.dynamic) {
+  render: function Render({ form, name, label, options, dynamic, placeholder }) {
+    if ((options?.length ?? 0) > 0 && dynamic) {
       throw new Error(
-        "The props 'staticOptions' and 'dynamic' are mutually exclusive. Please choose one or the other.",
+        "The props 'options' and 'dynamic' are mutually exclusive. Please choose one or the other.",
       )
     }
-
-    const [options, setOptions] = useState(staticOptions || [])
-    const [loading, setLoading] = useState(false)
 
     return (
       <form.AppField
@@ -67,32 +85,15 @@ export const Select = withForm({
         validators={{
           onChangeAsyncDebounceMs: 200,
           onChangeAsync: async ({ value }) => {
-            if (actions?.dynamic) {
-              setLoading(true)
-              const data = await searchProducts(value as string)
-              setLoading(false)
-              setOptions(data)
-            }
+            if (dynamic) return !value ? "Champs requis" : undefined
           },
           onChange: ({ value }) => {
-            if (actions?.dynamic) {
-              return !value ? "Champs requis" : undefined
-            }
-
-            if (staticOptions) {
-              for (const option of staticOptions) {
-                if (value === option.name) {
-                  return option.available ? undefined : "Bientôt disponible"
-                }
-              }
-
+            if (options) {
               if (!value) {
                 return "Champs requis"
               }
 
-              return staticOptions.some((option) => option.name === value)
-                ? false
-                : "Champs invalides"
+              return options.some((option) => option.name === value) ? false : "Champs invalides"
             }
           },
         }}
@@ -101,10 +102,9 @@ export const Select = withForm({
           <field.SelectField
             name={name}
             label={label}
-            actions={actions}
             placeholder={placeholder}
-            loading={loading}
-            staticOptions={options}
+            options={options}
+            dynamic={dynamic}
           />
         )}
       </form.AppField>

--- a/apps/web/src/components/Forms/types.ts
+++ b/apps/web/src/components/Forms/types.ts
@@ -18,6 +18,7 @@ const InputSchema = z.object({
   name: z.custom<FormLabel>(),
   type: z.enum(["text", "number"]).optional(),
   placeholder: z.string(),
+  disabled: z.boolean(),
 })
 
 export type InputProps = z.infer<typeof InputSchema>
@@ -35,22 +36,17 @@ const SelectSchema = z.object({
   label: z.string(),
   name: z.custom<FormLabel>(),
   placeholder: z.string(),
-  staticOptions: z
+  options: z
     .array(
       z.object({
         name: z.string(),
         available: z.boolean().optional(),
+        value: z.string().optional(),
       }),
     )
     .optional(),
-  watch: z.function().optional(),
+  dynamic: z.string().optional(),
   loading: z.boolean().optional(),
-  actions: z
-    .object({
-      dynamic: z.boolean().optional(),
-      handleOnFocus: z.function(z.tuple([z.custom<TaxSimulatorFormLabel>()])).optional(),
-    })
-    .optional(),
 })
 
 export type SelectProps = z.infer<typeof SelectSchema>


### PR DESCRIPTION
Refactors and improves the Input and Select form components for better flexibility, seperate the logic from Tanstack Form

* Replaced `staticOptions` and `actions` props with a unified `options` and `dynamic` prop, simplifying the API and removing mutually exclusive logic

* Integrated `react-query` for dynamic option fetching in `SelectField`, improving loading state management and stale data handling

* Removed unused props and methods, such as `onWatch` from `OptionsList` and legacy focus handling