### PR TITLE
refactor: split routes into modular files

### DIFF
--- a/apps/api/.adonisjs/client/manifest.d.ts
+++ b/apps/api/.adonisjs/client/manifest.d.ts
@@ -9,4 +9,3 @@
 /// <reference path="../../config/limiter.ts" />
 /// <reference path="../../config/logger.ts" />
 /// <reference path="../../config/redis.ts" />
-/// <reference path="../../config/shield.ts" />

--- a/apps/api/.adonisjs/server/routes.d.ts
+++ b/apps/api/.adonisjs/server/routes.d.ts
@@ -4,56 +4,46 @@ type ParamValue = string | number | bigint | boolean
 
 export type ScannedRoutes = {
   ALL: {
-    search_products: { paramsTuple?: []; params?: {} }
     "origins.list": { paramsTuple?: []; params?: {} }
+    search_products: { paramsTuple?: []; params?: {} }
     calculate_parcel: { paramsTuple?: []; params?: {} }
     get_templates: { paramsTuple?: []; params?: {} }
     "categories.count": { paramsTuple?: []; params?: {} }
     "categories.with_stats": { paramsTuple?: []; params?: {} }
+    "categories.index": { paramsTuple?: []; params?: {} }
+    "categories.store": { paramsTuple?: []; params?: {} }
+    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "categories.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "categories.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "origins.count": { paramsTuple?: []; params?: {} }
     "origins.top": { paramsTuple?: []; params?: {} }
+    "origins.index": { paramsTuple?: []; params?: {} }
+    "origins.store": { paramsTuple?: []; params?: {} }
+    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "origins.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "origins.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "territories.count": { paramsTuple?: []; params?: {} }
-    "territories.top": { paramsTuple?: []; params?: {} }
-    "transporters.count": { paramsTuple?: []; params?: {} }
-    "transporters.list": { paramsTuple?: []; params?: {} }
     "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
-    "categories.index": { paramsTuple?: []; params?: {} }
-    "categories.create": { paramsTuple?: []; params?: {} }
-    "categories.store": { paramsTuple?: []; params?: {} }
-    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "categories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "categories.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "categories.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.index": { paramsTuple?: []; params?: {} }
-    "origins.create": { paramsTuple?: []; params?: {} }
-    "origins.store": { paramsTuple?: []; params?: {} }
-    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.index": { paramsTuple?: []; params?: {} }
-    "products.create": { paramsTuple?: []; params?: {} }
     "products.store": { paramsTuple?: []; params?: {} }
     "products.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "products.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "territories.count": { paramsTuple?: []; params?: {} }
+    "territories.top": { paramsTuple?: []; params?: {} }
     "territories.index": { paramsTuple?: []; params?: {} }
-    "territories.create": { paramsTuple?: []; params?: {} }
     "territories.store": { paramsTuple?: []; params?: {} }
     "territories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "territories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "territories.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "territories.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "transporters.count": { paramsTuple?: []; params?: {} }
+    "transporters.list": { paramsTuple?: []; params?: {} }
     "transporters.index": { paramsTuple?: []; params?: {} }
-    "transporters.create": { paramsTuple?: []; params?: {} }
     "transporters.store": { paramsTuple?: []; params?: {} }
     "transporters.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "transporters.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "transporters.update": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "transporters.destroy": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "transporter_rules.show": { paramsTuple: [ParamValue]; params: { transporterId: ParamValue } }
@@ -71,81 +61,61 @@ export type ScannedRoutes = {
     }
   }
   GET: {
-    search_products: { paramsTuple?: []; params?: {} }
     "origins.list": { paramsTuple?: []; params?: {} }
+    search_products: { paramsTuple?: []; params?: {} }
     get_templates: { paramsTuple?: []; params?: {} }
     "categories.count": { paramsTuple?: []; params?: {} }
     "categories.with_stats": { paramsTuple?: []; params?: {} }
+    "categories.index": { paramsTuple?: []; params?: {} }
+    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "origins.count": { paramsTuple?: []; params?: {} }
     "origins.top": { paramsTuple?: []; params?: {} }
+    "origins.index": { paramsTuple?: []; params?: {} }
+    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "territories.count": { paramsTuple?: []; params?: {} }
-    "territories.top": { paramsTuple?: []; params?: {} }
-    "transporters.count": { paramsTuple?: []; params?: {} }
-    "transporters.list": { paramsTuple?: []; params?: {} }
     "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
-    "categories.index": { paramsTuple?: []; params?: {} }
-    "categories.create": { paramsTuple?: []; params?: {} }
-    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "categories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.index": { paramsTuple?: []; params?: {} }
-    "origins.create": { paramsTuple?: []; params?: {} }
-    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.index": { paramsTuple?: []; params?: {} }
-    "products.create": { paramsTuple?: []; params?: {} }
     "products.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "products.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "territories.count": { paramsTuple?: []; params?: {} }
+    "territories.top": { paramsTuple?: []; params?: {} }
     "territories.index": { paramsTuple?: []; params?: {} }
-    "territories.create": { paramsTuple?: []; params?: {} }
     "territories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "territories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "transporters.count": { paramsTuple?: []; params?: {} }
+    "transporters.list": { paramsTuple?: []; params?: {} }
     "transporters.index": { paramsTuple?: []; params?: {} }
-    "transporters.create": { paramsTuple?: []; params?: {} }
     "transporters.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "transporters.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "transporter_rules.show": { paramsTuple: [ParamValue]; params: { transporterId: ParamValue } }
   }
   HEAD: {
-    search_products: { paramsTuple?: []; params?: {} }
     "origins.list": { paramsTuple?: []; params?: {} }
+    search_products: { paramsTuple?: []; params?: {} }
     get_templates: { paramsTuple?: []; params?: {} }
     "categories.count": { paramsTuple?: []; params?: {} }
     "categories.with_stats": { paramsTuple?: []; params?: {} }
+    "categories.index": { paramsTuple?: []; params?: {} }
+    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "origins.count": { paramsTuple?: []; params?: {} }
     "origins.top": { paramsTuple?: []; params?: {} }
+    "origins.index": { paramsTuple?: []; params?: {} }
+    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "territories.count": { paramsTuple?: []; params?: {} }
-    "territories.top": { paramsTuple?: []; params?: {} }
-    "transporters.count": { paramsTuple?: []; params?: {} }
-    "transporters.list": { paramsTuple?: []; params?: {} }
     "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
-    "categories.index": { paramsTuple?: []; params?: {} }
-    "categories.create": { paramsTuple?: []; params?: {} }
-    "categories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "categories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.index": { paramsTuple?: []; params?: {} }
-    "origins.create": { paramsTuple?: []; params?: {} }
-    "origins.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "origins.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "products.index": { paramsTuple?: []; params?: {} }
-    "products.create": { paramsTuple?: []; params?: {} }
     "products.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "products.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "territories.count": { paramsTuple?: []; params?: {} }
+    "territories.top": { paramsTuple?: []; params?: {} }
     "territories.index": { paramsTuple?: []; params?: {} }
-    "territories.create": { paramsTuple?: []; params?: {} }
     "territories.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "territories.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
+    "transporters.count": { paramsTuple?: []; params?: {} }
+    "transporters.list": { paramsTuple?: []; params?: {} }
     "transporters.index": { paramsTuple?: []; params?: {} }
-    "transporters.create": { paramsTuple?: []; params?: {} }
     "transporters.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
-    "transporters.edit": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
     "transporter_rules.show": { paramsTuple: [ParamValue]; params: { transporterId: ParamValue } }
   }
   POST: {

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -8,81 +8,35 @@
 */
 
 import router from "@adonisjs/core/services/router"
-
 import { middleware } from "#start/kernel"
-import {
-  calculateParcelThrottle,
-  getTemplatesThrottle,
-  searchProductsThrottle,
-  transporterRulesThrottle,
-} from "#start/limiter"
 
-import { controllers } from "#generated/controllers"
+import registerAdminCategories from "#start/routes/admin/categories"
+import registerAdminOrigins from "#start/routes/admin/origins"
+import registerAdminProducts from "#start/routes/admin/products"
+import registerAdminTerritories from "#start/routes/admin/territories"
+import registerAdminTransporters from "#start/routes/admin/transporters"
+
+import registerPublicOrigins from "#start/routes/public/origins"
+import registerPublicProducts from "#start/routes/public/products"
+import registerPublicSimulator from "#start/routes/public/simulator"
 
 // ─── Public routes ───────────────────────────────────────
 router
   .group(() => {
-    router.get("/products/search", [controllers.SearchProducts]).use([searchProductsThrottle])
-    router.get("/origins", [controllers.Origins, "list"])
-    router.post("/simulator/parcel", [controllers.CalculateParcel]).use([calculateParcelThrottle])
-    router.get("/simulator/templates", [controllers.GetTemplates]).use([getTemplatesThrottle])
+    registerPublicOrigins(router)
+    registerPublicProducts(router)
+    registerPublicSimulator(router)
   })
   .prefix("/v1/public")
 
-// ─── Admin routes ───────────────────────────────────────────
+// ─── Admin routes ────────────────────────────────────────
 router
   .group(() => {
-    router.get("/categories/count", [controllers.Categories, "count"])
-    router.get("/categories/stats", [controllers.Categories, "withStats"])
-
-    router.get("/origins/count", [controllers.Origins, "count"])
-    router.get("/origins/top", [controllers.Origins, "top"])
-
-    router.get("/products/count", [controllers.Products, "count"])
-    router.get("/products/recent", [controllers.Products, "recent"])
-    router.get("/products/distribution", [controllers.Products, "distribution"])
-
-    router.get("/territories/count", [controllers.Territories, "count"])
-    router.get("/territories/top", [controllers.Territories, "top"])
-
-    router.get("/transporters/count", [controllers.Transporters, "count"])
-    router.get("/transporters/list", [controllers.Transporters, "list"])
-
-    router.get("/flux", [controllers.Products, "listFlux"])
-    router.get("/taxes", [controllers.Products, "listTaxes"])
-
-    router
-      .resource("categories", controllers.Categories)
-      .use(["index", "store", "show", "update", "destroy"], middleware.auth())
-
-    router
-      .resource("origins", controllers.Origins)
-      .use(["index", "store", "update", "destroy"], middleware.auth())
-
-    router
-      .resource("products", controllers.Products)
-      .use(["index", "store", "show", "update", "destroy"], middleware.auth())
-
-    router
-      .resource("territories", controllers.Territories)
-      .use(["index", "store", "show", "update", "destroy"], middleware.auth())
-
-    router
-      .resource("transporters", controllers.Transporters)
-      .use(["index", "store", "show", "update", "destroy"], middleware.auth())
-
-    router
-      .get("/transporters/:transporterId/rules", [controllers.TransporterRules, "show"])
-      .use([transporterRulesThrottle])
-    router
-      .post("/transporters/:transporterId/rules/flow", [controllers.TransporterRules, "saveFlow"])
-      .use([transporterRulesThrottle])
-    router
-      .post("/transporters/:transporterId/rules/fees", [controllers.TransporterRules, "saveRules"])
-      .use([transporterRulesThrottle])
-    router
-      .post("/transporters/:transporterId/rules", [controllers.TransporterRules, "saveAll"])
-      .use([transporterRulesThrottle])
+    registerAdminCategories(router)
+    registerAdminOrigins(router)
+    registerAdminProducts(router)
+    registerAdminTerritories(router)
+    registerAdminTransporters(router)
   })
   .use([middleware.auth()])
   .prefix("/v1/admin")

--- a/apps/api/start/routes/admin/categories.ts
+++ b/apps/api/start/routes/admin/categories.ts
@@ -1,0 +1,10 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+
+export default function registerCategoriesRoutes(router: HttpRouterService) {
+  const CategoriesController = controllers.Categories
+
+  router.get("/categories/count", [CategoriesController, "count"])
+  router.get("/categories/stats", [CategoriesController, "withStats"])
+  router.resource("categories", CategoriesController).apiOnly()
+}

--- a/apps/api/start/routes/admin/origins.ts
+++ b/apps/api/start/routes/admin/origins.ts
@@ -1,0 +1,10 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+
+export default function registerOriginsRoutes(router: HttpRouterService) {
+  const OriginsController = controllers.Origins
+
+  router.get("/origins/count", [OriginsController, "count"])
+  router.get("/origins/top", [OriginsController, "top"])
+  router.resource("origins", OriginsController).apiOnly()
+}

--- a/apps/api/start/routes/admin/products.ts
+++ b/apps/api/start/routes/admin/products.ts
@@ -1,0 +1,13 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+
+export default function registerProductsRoutes(router: HttpRouterService) {
+  const ProductsController = controllers.Products
+
+  router.get("/products/count", [ProductsController, "count"])
+  router.get("/products/recent", [ProductsController, "recent"])
+  router.get("/products/distribution", [ProductsController, "distribution"])
+  router.get("/products/flux", [ProductsController, "listFlux"])
+  router.get("/products/taxes", [ProductsController, "listTaxes"])
+  router.resource("products", ProductsController).apiOnly()
+}

--- a/apps/api/start/routes/admin/territories.ts
+++ b/apps/api/start/routes/admin/territories.ts
@@ -1,0 +1,10 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+
+export default function registerTerritoriesRoutes(router: HttpRouterService) {
+  const TerritoriesController = controllers.Territories
+
+  router.get("/territories/count", [TerritoriesController, "count"])
+  router.get("/territories/top", [TerritoriesController, "top"])
+  router.resource("territories", TerritoriesController).apiOnly()
+}

--- a/apps/api/start/routes/admin/transporters.ts
+++ b/apps/api/start/routes/admin/transporters.ts
@@ -1,0 +1,25 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+import { transporterRulesThrottle } from "#start/limiter"
+
+export default function registerTransportersRoutes(router: HttpRouterService) {
+  const TransportersController = controllers.Transporters
+  const TransporterRulesController = controllers.TransporterRules
+
+  router.get("/transporters/count", [TransportersController, "count"])
+  router.get("/transporters/list", [TransportersController, "list"])
+  router.resource("transporters", TransportersController).apiOnly()
+
+  router
+    .get("/transporters/:transporterId/rules", [TransporterRulesController, "show"])
+    .use([transporterRulesThrottle])
+  router
+    .post("/transporters/:transporterId/rules/flow", [TransporterRulesController, "saveFlow"])
+    .use([transporterRulesThrottle])
+  router
+    .post("/transporters/:transporterId/rules/fees", [TransporterRulesController, "saveRules"])
+    .use([transporterRulesThrottle])
+  router
+    .post("/transporters/:transporterId/rules", [TransporterRulesController, "saveAll"])
+    .use([transporterRulesThrottle])
+}

--- a/apps/api/start/routes/public/origins.ts
+++ b/apps/api/start/routes/public/origins.ts
@@ -1,0 +1,8 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+
+export default function registerPublicOriginsRoutes(router: HttpRouterService) {
+  const OriginsController = controllers.Origins
+
+  router.get("/origins", [OriginsController, "list"])
+}

--- a/apps/api/start/routes/public/products.ts
+++ b/apps/api/start/routes/public/products.ts
@@ -1,0 +1,9 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+import { searchProductsThrottle } from "#start/limiter"
+
+export default function registerPublicProductsRoutes(router: HttpRouterService) {
+  const SearchProductsController = controllers.SearchProducts
+
+  router.get("/products/search", [SearchProductsController, "handle"]).use([searchProductsThrottle])
+}

--- a/apps/api/start/routes/public/simulator.ts
+++ b/apps/api/start/routes/public/simulator.ts
@@ -1,0 +1,13 @@
+import type { HttpRouterService } from "@adonisjs/core/types"
+import { controllers } from "#generated/controllers"
+import { calculateParcelThrottle, getTemplatesThrottle } from "#start/limiter"
+
+export default function registerSimulatorRoutes(router: HttpRouterService) {
+  const CalculateParcelController = controllers.CalculateParcel
+  const GetTemplatesController = controllers.GetTemplates
+
+  router
+    .post("/simulator/parcel", [CalculateParcelController, "handle"])
+    .use([calculateParcelThrottle])
+  router.get("/simulator/templates", [GetTemplatesController, "handle"]).use([getTemplatesThrottle])
+}


### PR DESCRIPTION
Refactors the route definitions in the API by modularizing them into separate files based on their domain (admin/public and resource type). This improves maintainability and clarity by grouping related routes together and reducing the size and complexity of the main `routes.ts` file.