### PR TITLE
refactor: rework form composition with nextjs

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,9 +12,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@tanstack/react-form": "1.28.6",
     "@tanstack/react-query": "5.97.0",
     "@tanstack/react-router": "1.168.10",
+    "@tanstack/react-form": "1.29.0",
     "@tanstack/react-table": "8.21.3",
     "@tanstack/react-virtual": "3.13.23",
     "@xyflow/react": "^12.10.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "5.97.0",
-    "@tanstack/react-form": "1.28.6",
-    "@tanstack/react-form-nextjs": "1.28.6",
+    "@tanstack/react-form": "1.29.0",
+    "@tanstack/react-form-nextjs": "1.29.0",
     "@tanstack/react-virtual": "3.13.23",
     "@wrksz/themes": "^0.8.3",
     "motion": "12.38.0",

--- a/apps/web/src/actions/calculateParcel.ts
+++ b/apps/web/src/actions/calculateParcel.ts
@@ -1,16 +1,15 @@
 "use server"
 
-import type { ParcelSimulatorFormValues } from "@/components/services/ParcelSimulator/types"
-
-import { ServerValidateError, createServerValidate } from "@tanstack/react-form/nextjs"
+import { ServerValidateError, createServerValidate } from "@tanstack/react-form-nextjs"
 
 import { validateTurnstileCaptcha } from "@/actions/validateTurnstileToken"
-import { formOpts } from "@/hooks/form"
+import { parcelFormOpts } from "@/shared/formOpts"
+import { ParcelSimulatorSchema } from "@/components/services/ParcelSimulator/types"
 
 const serverValidate = createServerValidate({
-  ...formOpts,
+  ...parcelFormOpts,
   onServerValidate: ({ value }) => {
-    if (!value.products) {
+    if (!value.products || value.products.length === 0) {
       return "Please add at least one product"
     }
 
@@ -21,34 +20,43 @@ const serverValidate = createServerValidate({
 })
 
 export default async function calculateParcel(prev: unknown, formData: FormData) {
-  const products: ParcelSimulatorFormValues["products"] = []
+  const raw = {
+    customer: formData.get("customer") as string,
+    deliveryPrice: formData.get("deliveryPrice") as string,
+    origin: formData.get("origin") as string,
+    territory: formData.get("territory") as string,
+    transporter: formData.get("transporter") as string,
+    "cf-turnstile-response": formData.get("cf-turnstile-response") as string,
+    products: [] as { name: string; price: number }[],
+    enterprise:
+      formData.get("enterprise") === "on"
+        ? true
+        : formData.get("enterprise") === "true"
+          ? true
+          : false,
+    taxPaid:
+      formData.get("taxPaid") === "on" ? true : formData.get("taxPaid") === "true" ? true : false,
+  }
+
   formData.forEach((value, key) => {
-    if (key.startsWith("products[")) {
-      const index = key.match(/products\[(\d+)\]\.(\w+)/)
-      if (index) {
-        const field = index[2] as keyof ParcelSimulatorFormValues["products"][number]
-        const indexNumber = Number.parseInt(index[1], 10)
-        products[indexNumber] =
-          products[indexNumber] || ({} as ParcelSimulatorFormValues["products"][number])
-        // @ts-ignore
-        products[indexNumber][field] = value
+    const productsMatch = key.match(/^products\[(\d+)\]\.(\w+)$/)
+    if (productsMatch) {
+      const index = Number.parseInt(productsMatch[1], 10)
+      const field = productsMatch[2] as "name" | "price"
+      raw.products[index] = raw.products[index] || { name: "", price: 0 }
+      if (field === "price") {
+        raw.products[index].price = Number(value)
+      } else {
+        raw.products[index][field] = value as string
       }
     }
   })
 
-  const value = {
-    customer: formData.get("customer"),
-    deliveryPrice: formData.get("deliveryPrice"),
-    origin: formData.get("origin"),
-    products,
-    territory: formData.get("territory"),
-    transporter: formData.get("transporter"),
-    token: formData.get("cf-turnstile-response"),
-  }
-
   try {
     await serverValidate(formData)
-    await validateTurnstileCaptcha(value.token as string)
+
+    const parsed = ParcelSimulatorSchema.parse(raw)
+    await validateTurnstileCaptcha(parsed["cf-turnstile-response"])
 
     const res = await fetch(`${process.env.API_URL}/simulator/parcel`, {
       method: "POST",
@@ -56,7 +64,15 @@ export default async function calculateParcel(prev: unknown, formData: FormData)
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.API_KEY}`,
       },
-      body: JSON.stringify(value),
+      body: JSON.stringify({
+        customer: parsed.customer,
+        deliveryPrice: parsed.deliveryPrice,
+        origin: parsed.origin,
+        products: parsed.products,
+        territory: parsed.territory,
+        transporter: parsed.transporter,
+        token: parsed["cf-turnstile-response"],
+      }),
     }).then((res) => res.json())
 
     return res

--- a/apps/web/src/actions/getProductTaxes.ts
+++ b/apps/web/src/actions/getProductTaxes.ts
@@ -4,6 +4,7 @@ import { ServerValidateError, createServerValidate } from "@tanstack/react-form-
 
 import { validateTurnstileCaptcha } from "@/actions/validateTurnstileToken"
 import { taxFormOpts } from "@/shared/formOpts"
+import { TaxSimulatorFormSchema } from "@/components/services/TaxSimulator/types"
 
 const serverValidate = createServerValidate({
   ...taxFormOpts,
@@ -19,23 +20,30 @@ const serverValidate = createServerValidate({
 })
 
 export default async function getProductTaxes(prev: unknown, formData: FormData) {
-  const value = {
-    product: formData.get("product"),
-    origin: formData.get("origin"),
-    territory: formData.get("territory"),
-    token: formData.get("cf-turnstile-response"),
-  }
-
   try {
     await serverValidate(formData)
-    await validateTurnstileCaptcha(value.token as string)
+
+    const raw = {
+      product: formData.get("product") as string,
+      origin: formData.get("origin") as string,
+      territory: formData.get("territory") as string,
+      token: formData.get("cf-turnstile-response") as string,
+    }
+
+    const parsed = TaxSimulatorFormSchema.parse(raw)
+    await validateTurnstileCaptcha(parsed["cf-turnstile-response"])
 
     const res = await fetch(`${process.env.API_URL}/products/taxes`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(value),
+      body: JSON.stringify({
+        product: parsed.product,
+        origin: parsed.origin,
+        territory: parsed.territory,
+        token: parsed["cf-turnstile-response"],
+      }),
     }).then((res) => res.json())
 
     return res

--- a/apps/web/src/components/Forms/Radio/index.tsx
+++ b/apps/web/src/components/Forms/Radio/index.tsx
@@ -18,9 +18,9 @@ export default function RadioField({ name, label, options, disabled = false }: R
                 type="radio"
                 id={option}
                 name={field.name}
-                value={field.state.value}
-                onClick={() => field.setValue(option)}
-                defaultChecked={field.state.value === option}
+                value={option}
+                checked={field.state.value === option}
+                onChange={() => field.setValue(option)}
                 disabled={disabled}
               />
               <label htmlFor={option}>{option.toString()}</label>

--- a/apps/web/src/components/Forms/Select/BaseSelect.tsx
+++ b/apps/web/src/components/Forms/Select/BaseSelect.tsx
@@ -3,16 +3,19 @@
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { AnimatePresence } from "motion/react"
 import * as m from "motion/react-m"
-import { useEffect, useRef, useState, type InputHTMLAttributes, type KeyboardEvent } from "react"
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type InputHTMLAttributes,
+  type KeyboardEvent,
+} from "react"
+
+import type { SelectOption } from "@taxdom/types"
 
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import { LoadingCircle, OptionContainer } from "./Select.styled"
-
-export interface BaseOption {
-  name: string
-  available?: boolean
-  value?: string
-}
 
 type NativeInputProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -24,7 +27,7 @@ export interface BaseSelectProps extends NativeInputProps {
   name?: string
   label: string
   placeholder?: string
-  options: BaseOption[]
+  options: SelectOption[]
   value: string
   onChange: (value: string) => void
   onBlur?: () => void
@@ -36,46 +39,31 @@ export interface BaseSelectProps extends NativeInputProps {
 }
 
 interface OptionsListProps {
-  options: BaseOption[]
-  value: string
+  options: SelectOption[]
   onSelect: (value: string) => void
   selectedIndex: number
   setSelectedIndex: (index: number) => void
 }
 
-const OptionsList = ({
-  options,
-  value,
-  onSelect,
-  selectedIndex,
-  setSelectedIndex,
-}: OptionsListProps) => {
+const OptionsList = ({ options, onSelect, selectedIndex, setSelectedIndex }: OptionsListProps) => {
   const parentRef = useRef<HTMLUListElement>(null)
   const itemHeight = 35
   const maxVisibleItems = 6
 
-  const filteredOptions = options.filter((option) => {
-    const lowerCaseValue = value.toLowerCase()
-    const exactMatchFound =
-      lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-    const lowerCaseOption = option.name.toLowerCase()
-    return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-  })
-
-  const shouldVirtualize = filteredOptions.length > maxVisibleItems
+  const shouldVirtualize = options.length > maxVisibleItems
 
   const containerHeight = shouldVirtualize
     ? maxVisibleItems * itemHeight
-    : filteredOptions.length * itemHeight
+    : options.length * itemHeight
 
   const virtualizer = useVirtualizer({
-    count: filteredOptions.length,
+    count: options.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => itemHeight,
     overscan: 5,
   })
 
-  if (filteredOptions.length === 0) return null
+  if (options.length === 0) return null
 
   return (
     <OptionContainer
@@ -95,7 +83,7 @@ const OptionsList = ({
           }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
-            const option = filteredOptions[virtualItem.index]
+            const option = options[virtualItem.index]
             return (
               <li
                 key={option.name}
@@ -121,7 +109,7 @@ const OptionsList = ({
           })}
         </div>
       ) : (
-        filteredOptions.map((option, index) => (
+        options.map((option, index) => (
           <li
             key={option.name}
             data-selected={index === selectedIndex}
@@ -166,27 +154,25 @@ export default function BaseSelect({
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [show, setShow] = useState(false)
 
-  // Keep the ref in sync with the visual selected index (mouse or keyboard)
   useEffect(() => {
     selectedIndexRef.current = selectedIndex
   }, [selectedIndex])
 
+  const filteredOptions = useMemo(() => {
+    if (!value) return options
+    const lower = value.toLowerCase()
+    const exactMatch = options.some((opt) => opt.name.toLowerCase() === lower)
+    if (exactMatch) return []
+    return options.filter((opt) => opt.name.toLowerCase().includes(lower))
+  }, [options, value])
+
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (options?.length === 0) return
+    if (filteredOptions.length === 0) return
 
     if (e.key === "ArrowUp" || e.key === "ArrowDown") {
       e.preventDefault()
       setSelectedIndex((prevIndex) => {
-        const filteredOptions = options.filter((option) => {
-          const lowerCaseValue = value.toLowerCase()
-          const exactMatchFound =
-            lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-          const lowerCaseOption = option.name.toLowerCase()
-          return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-        })
-
         if (filteredOptions.length === 0) return prevIndex
-
         const newIndex =
           e.key === "ArrowUp"
             ? (prevIndex - 1 + filteredOptions.length) % filteredOptions.length
@@ -198,14 +184,6 @@ export default function BaseSelect({
 
     if (e.key === "Enter") {
       e.preventDefault()
-      const filteredOptions = options.filter((option) => {
-        const lowerCaseValue = value.toLowerCase()
-        const exactMatchFound =
-          lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-        const lowerCaseOption = option.name.toLowerCase()
-        return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-      })
-
       const selectedOption = filteredOptions[selectedIndexRef.current]
       if (selectedOption) {
         onChange(selectedOption.value || selectedOption.name)
@@ -247,7 +225,7 @@ export default function BaseSelect({
       />
       {loading && <LoadingCircle />}
       <AnimatePresence>
-        {options.length > 0 && show && (
+        {filteredOptions.length > 0 && show && (
           <m.div
             style={{ zIndex: 1, height: "100%" }}
             initial={{ translateY: "-5px", opacity: 0 }}
@@ -255,8 +233,7 @@ export default function BaseSelect({
             exit={{ translateY: "5px", opacity: 0 }}
           >
             <OptionsList
-              options={options}
-              value={value}
+              options={filteredOptions}
               onSelect={(selectedValue) => {
                 onChange(selectedValue)
                 setShow(false)

--- a/apps/web/src/components/Forms/Select/index.tsx
+++ b/apps/web/src/components/Forms/Select/index.tsx
@@ -1,49 +1,12 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
-
 import { formOpts, useFieldContext, withForm } from "@/hooks/form"
 
-import type { SelectProps } from "@/components/Forms/types"
+import type { SelectFieldProps, SelectProps } from "@/components/Forms/types"
 import BaseSelect from "./BaseSelect"
 
-export default function SelectField({
-  label,
-  options = [],
-  dynamic,
-  loading,
-  placeholder,
-}: SelectProps) {
+function SelectField({ label, options = [], placeholder, loading }: SelectFieldProps) {
   const field = useFieldContext<string>()
-  const currentValue = field.state.value || ""
-
-  const enabled = Boolean(dynamic && currentValue)
-
-  const { data: dynamicOptions = [], isFetching } = useQuery<
-    { name: string; value?: string }[],
-    Error
-  >({
-    queryKey: ["select-options", dynamic, currentValue],
-    queryFn: async () => {
-      const path = dynamic ?? ""
-      const url = path.startsWith("http") ? new URL(path) : new URL(path, window.location.origin)
-      url.searchParams.set("name", currentValue)
-      const res = await fetch(url.toString(), {
-        method: "GET",
-        headers: { "content-type": "application/json" },
-      })
-      if (!res.ok) throw new Error("Failed to fetch options")
-      return (await res.json()) as { name: string; value?: string }[]
-    },
-    enabled,
-    staleTime: 30_000,
-  })
-
-  const mergedOptions = useMemo(
-    () => (dynamic ? dynamicOptions : (options ?? [])),
-    [dynamic, dynamicOptions, options],
-  )
 
   return (
     <BaseSelect
@@ -51,16 +14,18 @@ export default function SelectField({
       name={field.name}
       label={label}
       placeholder={placeholder}
-      options={mergedOptions}
+      options={options}
       value={field.state.value ?? ""}
-      onChange={(value) => {
-        field.handleChange(value)
-      }}
+      onChange={(value) => field.handleChange(value)}
       onBlur={() => field.handleBlur()}
-      loading={loading || isFetching}
+      loading={loading}
       errors={field.state.meta.errors}
     />
   )
+}
+
+type SelectFormProps = SelectProps & {
+  form: unknown
 }
 
 export const Select = withForm({
@@ -69,32 +34,19 @@ export const Select = withForm({
     name: "" as SelectProps["name"],
     label: "",
     placeholder: "",
-    options: [],
-    actions: {},
-  } as SelectProps,
-  render: function Render({ form, name, label, options, dynamic, placeholder }) {
-    if ((options?.length ?? 0) > 0 && dynamic) {
-      throw new Error(
-        "The props 'options' and 'dynamic' are mutually exclusive. Please choose one or the other.",
-      )
-    }
-
+  } as SelectFormProps,
+  render: function Render({ form, name, label, options, onSearch, placeholder }) {
     return (
       <form.AppField
         name={name}
         validators={{
           onChangeAsyncDebounceMs: 200,
-          onChangeAsync: async ({ value }) => {
-            if (dynamic) return !value ? "Champs requis" : undefined
-          },
           onChange: ({ value }) => {
-            if (options) {
-              if (!value) {
-                return "Champs requis"
-              }
-
-              return options.some((option) => option.name === value) ? false : "Champs invalides"
+            if (!value) return "Champs requis"
+            if (options && options.length > 0) {
+              return options.some((opt) => opt.name === value) ? undefined : "Champs invalides"
             }
+            return undefined
           },
         }}
       >
@@ -103,11 +55,14 @@ export const Select = withForm({
             name={name}
             label={label}
             placeholder={placeholder}
-            options={options}
-            dynamic={dynamic}
+            options={options ?? []}
+            onSearch={onSearch}
           />
         )}
       </form.AppField>
     )
   },
 })
+
+export type { SelectFieldProps }
+export default SelectField

--- a/apps/web/src/components/Forms/types.ts
+++ b/apps/web/src/components/Forms/types.ts
@@ -1,3 +1,5 @@
+import type { SelectOption } from "@taxdom/types"
+
 import { z } from "zod"
 
 import type { ParcelSimulatorFormLabel } from "@/components/services/ParcelSimulator/types"
@@ -32,21 +34,30 @@ const RadioSchema = z.object({
 
 export type RadioProps = z.infer<typeof RadioSchema>
 
-const SelectSchema = z.object({
-  label: z.string(),
-  name: z.custom<FormLabel>(),
-  placeholder: z.string(),
-  options: z
-    .array(
-      z.object({
-        name: z.string(),
-        available: z.boolean().optional(),
-        value: z.string().optional(),
-      }),
-    )
-    .optional(),
-  dynamic: z.string().optional(),
-  loading: z.boolean().optional(),
-})
+export type SelectCommonProps = {
+  label: string
+  placeholder?: string
+  loading?: boolean
+}
 
-export type SelectProps = z.infer<typeof SelectSchema>
+export type SelectStaticProps = SelectCommonProps & {
+  options: SelectOption[]
+  onSearch?: never
+}
+
+export type SelectDynamicProps = SelectCommonProps & {
+  options?: never
+  onSearch: (query: string) => Promise<SelectOption[]>
+  searchDebounceMs?: number
+  searchMinChars?: number
+}
+
+export type SelectProps = (SelectStaticProps | SelectDynamicProps) & {
+  name: FormLabel
+}
+
+export type SelectFieldProps = Omit<SelectCommonProps, never> & {
+  options?: SelectOption[]
+  onSearch?: (query: string) => Promise<SelectOption[]>
+  name?: string
+}

--- a/apps/web/src/components/services/ParcelSimulator/ParcelSimulatorCards/index.tsx
+++ b/apps/web/src/components/services/ParcelSimulator/ParcelSimulatorCards/index.tsx
@@ -69,9 +69,7 @@ export const ParcelSimulatorCards = withForm({
                     name={`products[${i}].name`}
                     label="Produit"
                     placeholder="Type de produit"
-                    actions={{
-                      dynamic: true,
-                    }}
+                    options={[]}
                   />
                   <Input
                     {...{ form }}

--- a/apps/web/src/components/services/ParcelSimulator/ParcelSimulatorForm/index.tsx
+++ b/apps/web/src/components/services/ParcelSimulator/ParcelSimulatorForm/index.tsx
@@ -2,11 +2,15 @@
 
 import { mergeForm } from "@tanstack/react-form"
 import { initialFormState, useTransform } from "@tanstack/react-form-nextjs"
+import { useQuery } from "@tanstack/react-query"
 import { useActionState, useEffect } from "react"
 import { toast } from "sonner"
 
 import calculateParcel from "@/actions/calculateParcel"
 import { parcelFormOpts, useAppForm } from "@/hooks/form"
+import { originQueryOptions } from "@/lib/origins"
+import { territoryQueryOptions } from "@/lib/territories"
+import { transporterQueryOptions } from "@/lib/transporters"
 import Turnstile from "@/lib/Turnstile"
 import { useParcelSimulatorStore } from "@/providers/ParcelSimulatorStoreProvider"
 
@@ -21,7 +25,6 @@ export default function ParcelSimulator() {
   const setHasResult = useParcelSimulatorStore((s) => s.setHasResult)
   const setResult = useParcelSimulatorStore((s) => s.setResult)
 
-  // TODO: https://github.com/TanStack/form/issues/1018
   useEffect(() => {
     try {
       const errors = state.errors[0]?.message
@@ -54,16 +57,27 @@ export default function ParcelSimulator() {
     },
   })
 
+  const { data: originOptions = [] } = useQuery(originQueryOptions)
+  const { data: territoryOptions = [] } = useQuery(territoryQueryOptions)
+  const { data: transporterOptions = [] } = useQuery(transporterQueryOptions)
+
   return (
     <Container>
       <form action={action} onSubmit={() => form.handleSubmit()}>
         <div>
-          <Select {...{ form }} name="origin" label="Origine" placeholder="EU" />
+          <Select
+            {...{ form }}
+            name="origin"
+            label="Origine"
+            placeholder="EU"
+            options={originOptions}
+          />
           <Select
             {...{ form }}
             name="territory"
             label="Territoire d'application"
             placeholder="REUNION"
+            options={territoryOptions.map((t) => ({ name: t.territoryName, value: t.territoryID }))}
           />
           <Radio
             {...{ form }}
@@ -71,7 +85,13 @@ export default function ParcelSimulator() {
             label="Envoi entre particulier ?"
             options={["Oui", "Non"]}
           />
-          <Select {...{ form }} name="transporter" label="Transporteur" placeholder="COLISSIMO" />
+          <Select
+            {...{ form }}
+            name="transporter"
+            label="Transporteur"
+            placeholder="COLISSIMO"
+            options={transporterOptions}
+          />
           <Input
             {...{ form }}
             name="deliveryPrice"

--- a/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
+++ b/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
@@ -4,11 +4,15 @@ import type { TaxSimulatorFormLabel } from "../types"
 
 import { mergeForm } from "@tanstack/react-form"
 import { initialFormState, useTransform } from "@tanstack/react-form-nextjs"
+import { useQuery } from "@tanstack/react-query"
 import { useActionState, useEffect } from "react"
 import { toast } from "sonner"
 
+import type { SelectOption } from "@taxdom/types"
 import getProductTaxes from "@/actions/getProductTaxes"
 import { taxFormOpts, useAppForm } from "@/hooks/form"
+import { originQueryOptions } from "@/lib/origins"
+import { territoryQueryOptions } from "@/lib/territories"
 import Turnstile from "@/lib/Turnstile"
 import { useTaxSimulatorStore } from "@/providers/TaxSimulatorStoreProvider"
 
@@ -20,12 +24,10 @@ export default function TaxSimulatorForm() {
   const [state, action] = useActionState(getProductTaxes, initialFormState)
 
   const hasResult = useTaxSimulatorStore((s) => s.hasResult)
-  const setFocusInput = useTaxSimulatorStore((s) => s.setFocusInput)
   const setHasResult = useTaxSimulatorStore((s) => s.setHasResult)
   const setResult = useTaxSimulatorStore((s) => s.setResult)
   const setSelectedCountry = useTaxSimulatorStore((s) => s.setSelectedCountry)
 
-  // TODO: https://github.com/TanStack/form/issues/1018
   useEffect(() => {
     if (state.taxes) {
       setHasResult(true)
@@ -45,9 +47,8 @@ export default function TaxSimulatorForm() {
     },
   })
 
-  const handleFocusInput = (name: TaxSimulatorFormLabel) => {
-    if (!hasResult) setFocusInput(name)
-  }
+  const { data: originOptions = [] } = useQuery(originQueryOptions)
+  const { data: territoryOptions = [] } = useQuery(territoryQueryOptions)
 
   return (
     <form action={action} onSubmit={() => form.handleSubmit()}>
@@ -56,28 +57,21 @@ export default function TaxSimulatorForm() {
         name="product"
         label="Produit"
         placeholder="Type de produit"
-        actions={{
-          handleOnFocus: handleFocusInput,
-          dynamic: true,
-        }}
+        options={[] as SelectOption[]}
       />
       <Select
         {...{ form }}
         name="origin"
         label="Territoire d'origine"
         placeholder="EU"
-        actions={{
-          handleOnFocus: handleFocusInput,
-        }}
+        options={originOptions}
       />
       <Select
         {...{ form }}
         name="territory"
         label="Territoire d'application"
         placeholder="Réunion"
-        actions={{
-          handleOnFocus: handleFocusInput,
-        }}
+        options={territoryOptions.map((t) => ({ name: t.territoryName, value: t.territoryID }))}
       />
       <CaptchaContainer>
         <Radio {...{ form }} name="flux" label="Flux" options={["import", "export"]} disabled />

--- a/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
+++ b/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
@@ -8,7 +8,6 @@ import { useQuery } from "@tanstack/react-query"
 import { useActionState, useEffect } from "react"
 import { toast } from "sonner"
 
-import type { SelectOption } from "@taxdom/types"
 import getProductTaxes from "@/actions/getProductTaxes"
 import { taxFormOpts, useAppForm } from "@/hooks/form"
 import { originQueryOptions } from "@/lib/origins"
@@ -57,7 +56,7 @@ export default function TaxSimulatorForm() {
         name="product"
         label="Produit"
         placeholder="Type de produit"
-        options={[] as SelectOption[]}
+        options={[]}
       />
       <Select
         {...{ form }}

--- a/apps/web/src/lib/origins.ts
+++ b/apps/web/src/lib/origins.ts
@@ -1,0 +1,37 @@
+import type { SelectOption } from "@taxdom/types"
+import { queryOptions } from "@tanstack/react-query"
+
+export type OriginResponse = {
+  name: string
+  isEU: boolean
+}
+
+/**
+ * Fetch all available origins from the public API
+ */
+export async function fetchOrigins(): Promise<SelectOption[]> {
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/v1/public/origins`
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch origins: ${response.status} ${response.statusText}`)
+  }
+
+  const origins = (await response.json()) as OriginResponse[]
+  return origins.map((o) => ({
+    name: o.name,
+    available: true,
+  }))
+}
+
+export const originQueryOptions = queryOptions({
+  queryKey: ["origins"],
+  queryFn: fetchOrigins,
+  staleTime: 60 * 60 * 1000, // 1 hour for reference data
+})

--- a/apps/web/src/lib/territories.ts
+++ b/apps/web/src/lib/territories.ts
@@ -1,20 +1,18 @@
-import type { Territory } from "@taxdom/types"
+import type { SelectOption, Territory } from "@taxdom/types"
+import { queryOptions } from "@tanstack/react-query"
 
 /**
  * Fetch all available territories from the server
  */
 export async function fetchTerritories(): Promise<Territory[]> {
   try {
-    const url = `${process.env.API_URL || process.env.NEXT_PUBLIC_API_URL}/dashboard/territories`
+    const url = `${process.env.API_URL || process.env.NEXT_PUBLIC_API_URL}/v1/admin/territories`
 
     const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.API_KEY}`,
-      },
-      next: {
-        tags: ["territories"],
       },
     })
 
@@ -29,3 +27,9 @@ export async function fetchTerritories(): Promise<Territory[]> {
     return []
   }
 }
+
+export const territoryQueryOptions = queryOptions({
+  queryKey: ["territories"],
+  queryFn: fetchTerritories,
+  staleTime: 60 * 60 * 1000,
+})

--- a/apps/web/src/lib/transporters.ts
+++ b/apps/web/src/lib/transporters.ts
@@ -1,0 +1,38 @@
+import type { SelectOption, Transporter } from "@taxdom/types"
+import { queryOptions } from "@tanstack/react-query"
+
+/**
+ * Fetch all available transporters from the server
+ */
+export async function fetchTransporters(): Promise<SelectOption[]> {
+  try {
+    const url = `${process.env.API_URL || process.env.NEXT_PUBLIC_API_URL}/v1/admin/transporters/list`
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.API_KEY}`,
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch transporters: ${response.status} ${response.statusText}`)
+    }
+
+    const transporters = (await response.json()) as Transporter[]
+    return transporters.map((t) => ({
+      name: t.transporterName,
+      value: t.transporterID,
+    }))
+  } catch (error) {
+    console.error("Error fetching transporters:", error)
+    return []
+  }
+}
+
+export const transporterQueryOptions = queryOptions({
+  queryKey: ["transporters"],
+  queryFn: fetchTransporters,
+  staleTime: 60 * 60 * 1000,
+})

--- a/apps/web/src/shared/formOpts.ts
+++ b/apps/web/src/shared/formOpts.ts
@@ -1,4 +1,4 @@
-import { formOptions } from "@tanstack/react-form"
+import { formOptions } from "@tanstack/react-form-nextjs"
 import type { Transporter } from "@taxdom/types"
 import { z } from "zod"
 


### PR DESCRIPTION
Full refactor of the `Select` component for the tax simulator and parcel simulator. Three goals: fix a silent validation bug, remove dead code (`actions`/`dynamic` props), and prepare for Meilisearch integration.
## Changes
### `Select` component (core)
- **Types** — Replaced Zod `SelectSchema` with a discriminated union (`SelectStaticProps` / `SelectDynamicProps`). `name` no longer on field props, `loading` no longer on form props.
- **BaseSelect** — Removed `BaseOption`, now uses `SelectOption` from `@taxdom/types` directly. Extracted client-side filtering into `useMemo` (eliminated 3x duplication).
- **SelectField** — Removed hardcoded `useQuery`. Component is now a pure passthrough to `BaseSelect`. `onSearch` callback wired for Meilisearch.
- **Validation** — Fixed bug: `if (options)` → `if (options.length > 0)`. Before, any array (even empty `[]`) passed the check.
### Data fetching
- **`/v1/public/origins`** — Fixed endpoint: `/dashboard/origins` (admin) → `/v1/public/origins` (public).
- **territories** — Added `territoryQueryOptions` with endpoint `/v1/admin/territories`.
- **transporters** — New file `lib/transporters.ts` with `transporterQueryOptions` and field mapping `transporterName` → `name`, `transporterID` → `value`.
### Consumer updates
- **TaxSimulatorForm** — Removed dead `actions` prop from Selects. `origin` and `territory` fields now populated via `useQuery`.
- **ParcelSimulatorForm** — `origin`, `territory` and `transporter` fields now populated via `useQuery`.
- **ParcelSimulatorCards** — Removed dead `actions: { dynamic: true }` prop from `products[i].name`
## Breaking changes
- `actions` prop is no longer supported (was silently ignored).
- `dynamic` prop is no longer supported.
- `SelectFieldProps` no longer contains `name`.
## Next steps
- Meilisearch integration on `product` fields #86 