### PR TITLE
chore: improve vine validation

### DIFF
--- a/apps/api/app/controllers/CalculateParcelController.ts
+++ b/apps/api/app/controllers/CalculateParcelController.ts
@@ -54,9 +54,7 @@ function isEUCountry(country: string): boolean {
 
 export default class CalculateParcelController {
   async handle({ request }: HttpContext) {
-    const data = request.body()
-
-    const payload = await CalculateParcelTaxeValidator.validate(data)
+    const payload = await request.validateUsing(CalculateParcelTaxeValidator)
 
     const { customer, deliveryPrice, origin, products, transporter } = payload
 

--- a/apps/api/app/controllers/CategoriesController.ts
+++ b/apps/api/app/controllers/CategoriesController.ts
@@ -98,7 +98,7 @@ export default class CategoriesController {
    */
   async store({ request, response }: HttpContext) {
     try {
-      const validatedData = await CreateCategoryValidator.validate(request.all())
+      const validatedData = await request.validateUsing(CreateCategoryValidator)
       const { categoryName, tva, om, omr } = validatedData
 
       const existingCategory = await db.query.categories.findFirst({
@@ -259,7 +259,7 @@ export default class CategoriesController {
         })
       }
 
-      const validatedData = await UpdateCategoryValidator.validate(request.all())
+      const validatedData = await request.validateUsing(UpdateCategoryValidator)
       const { categoryName, taxID } = validatedData
 
       const duplicateCategory = await db.query.categories.findFirst({

--- a/apps/api/app/controllers/GetProductTaxesController.ts
+++ b/apps/api/app/controllers/GetProductTaxesController.ts
@@ -20,8 +20,7 @@ const territoryMap: Record<Territory, number> = {
 
 export default class GetProductTaxeController {
   async handle({ request }: HttpContext) {
-    const data = request.body()
-    const payload = await GetProductTaxeValidator.validate(data)
+    const payload = await request.validateUsing(GetProductTaxeValidator)
 
     const product = payload.product.toLowerCase()
     const origin = payload.origin.toUpperCase()

--- a/apps/api/app/controllers/ProductsController.ts
+++ b/apps/api/app/controllers/ProductsController.ts
@@ -188,7 +188,7 @@ export default class ProductsController {
    */
   async store({ request, response }: HttpContext) {
     try {
-      const validatedData = await CreateProductValidator.validate(request.all())
+      const validatedData = await request.validateUsing(CreateProductValidator)
       const { productName, categoryID, originID, territoryID, fluxID, taxID } = validatedData
 
       // Verify all FK entities exist
@@ -300,7 +300,7 @@ export default class ProductsController {
         return response.notFound({ error: "Produit non trouvé" })
       }
 
-      const validatedData = await UpdateProductValidator.validate(request.all())
+      const validatedData = await request.validateUsing(UpdateProductValidator)
       const { productName, categoryID, originID, territoryID, fluxID, taxID } = validatedData
 
       // Check for duplicate product name (excluding current product)

--- a/apps/api/app/controllers/SearchProductsController.ts
+++ b/apps/api/app/controllers/SearchProductsController.ts
@@ -6,8 +6,8 @@ import { SearchProductsValidator } from "#validators/SearchProductsValidator"
 
 export default class SearchProductsController {
   async handle({ request }: HttpContext) {
-    const filters = await SearchProductsValidator.validate(request.qs())
-    const productName = filters.name
+    const filters = await request.validateUsing(SearchProductsValidator)
+    const productName = filters.name.trim()
 
     if (!productName) {
       return { error: "Product name is required" }

--- a/apps/api/app/controllers/TerritoriesController.ts
+++ b/apps/api/app/controllers/TerritoriesController.ts
@@ -124,6 +124,8 @@ export default class TerritoriesController {
 
       const trimmedName = territoryName.trim().toUpperCase()
       const territoryID = uuidv7()
+      const validatedData = await request.validateUsing(createTerritoryValidator)
+      const trimmedName = validatedData.territoryName.trim().toUpperCase()
 
       const existingTerritory = await db.query.territories.findFirst({
         where: (territories, { eq }) => eq(territories.territoryName, trimmedName),
@@ -165,14 +167,14 @@ export default class TerritoriesController {
       const territoryIdParam: string = params.id
       if (!territoryIdParam) return response.status(400).json({ error: "Paramètre manquant" })
 
-      const { territoryName, available } = request.only(["territoryName", "available"])
+      const validatedData = await request.validateUsing(updateTerritoryValidator)
 
       const updateData: Partial<typeof territories.$inferInsert> = {}
-      if (typeof territoryName === "string" && territoryName.trim().length > 0) {
-        updateData.territoryName = territoryName.trim().toUpperCase()
+      if (validatedData.territoryName) {
+        updateData.territoryName = validatedData.territoryName.trim().toUpperCase()
       }
-      if (typeof available === "boolean") {
-        updateData.available = available
+      if (validatedData.available !== undefined) {
+        updateData.available = validatedData.available
       }
 
       if (Object.keys(updateData).length === 0) {

--- a/apps/api/app/controllers/TransporterRulesController.ts
+++ b/apps/api/app/controllers/TransporterRulesController.ts
@@ -124,7 +124,7 @@ export default class TransporterRulesController {
       let nodes: ValidatedFlowNode[]
       let edges: ValidatedFlowEdge[]
       try {
-        const parsed = await vine.validate({ schema: SaveFlowBodySchema, data: request.body() })
+        const parsed = await request.validateUsing(saveFlowValidator)
         nodes = parsed.nodes as ValidatedFlowNode[]
         edges = parsed.edges as ValidatedFlowEdge[]
       } catch (err) {
@@ -226,7 +226,7 @@ export default class TransporterRulesController {
 
       let rules: ValidatedFeeRule[]
       try {
-        const parsed = await vine.validate({ schema: SaveRulesBodySchema, data: request.body() })
+        const parsed = await request.validateUsing(saveRulesValidator)
         rules = parsed.rules as ValidatedFeeRule[]
       } catch (err) {
         return response
@@ -293,7 +293,7 @@ export default class TransporterRulesController {
       let edges: ValidatedFlowEdge[]
       let rules: ValidatedFeeRule[]
       try {
-        const parsed = await vine.validate({ schema: SaveAllBodySchema, data: request.body() })
+        const parsed = await request.validateUsing(saveAllValidator)
         nodes = parsed.nodes as ValidatedFlowNode[]
         edges = parsed.edges as ValidatedFlowEdge[]
         rules = parsed.rules as ValidatedFeeRule[]

--- a/apps/api/app/validators/CalculateParcelTaxeValidator.ts
+++ b/apps/api/app/validators/CalculateParcelTaxeValidator.ts
@@ -1,22 +1,17 @@
-import { OriginData, TerritoryData, TransporterData } from "@taxdom/types"
 import vine from "@vinejs/vine"
 
-const Origin = OriginData.map((o) => o.name)
-const Territory = TerritoryData.map((t) => t.name)
-const Transporter = TransporterData.map((t) => t.name)
-
-export const CalculateParcelTaxeValidator = vine.compile(
+export const CalculateParcelTaxeValidator = vine.create(
   vine.object({
     customer: vine.enum(["Oui", "Non"]),
     deliveryPrice: vine.number().positive(),
-    origin: vine.enum(Origin),
+    origin: vine.string(),
     products: vine.array(
       vine.object({
         name: vine.string().alphaNumeric(),
         price: vine.number().positive(),
       }),
     ),
-    territory: vine.enum(Territory),
-    transporter: vine.enum(Transporter),
+    territory: vine.string(),
+    transporter: vine.string(),
   }),
 )

--- a/apps/api/app/validators/CategoryValidator.ts
+++ b/apps/api/app/validators/CategoryValidator.ts
@@ -1,6 +1,6 @@
 import vine from "@vinejs/vine"
 
-export const CreateCategoryValidator = vine.compile(
+export const CreateCategoryValidator = vine.create(
   vine.object({
     categoryName: vine.string().trim().minLength(1).maxLength(255),
     tva: vine.number().min(0),
@@ -9,7 +9,7 @@ export const CreateCategoryValidator = vine.compile(
   }),
 )
 
-export const UpdateCategoryValidator = vine.compile(
+export const UpdateCategoryValidator = vine.create(
   vine.object({
     categoryName: vine.string().trim().minLength(1).maxLength(255),
     taxID: vine.string().uuid().optional(),

--- a/apps/api/app/validators/CreateProductValidator.ts
+++ b/apps/api/app/validators/CreateProductValidator.ts
@@ -1,23 +1,23 @@
 import vine from "@vinejs/vine"
 
-export const CreateProductValidator = vine.compile(
+export const CreateProductValidator = vine.create(
   vine.object({
     productName: vine.string().trim().minLength(1).maxLength(255),
     categoryID: vine.string().trim().minLength(1),
     originID: vine.string().trim().minLength(1),
     territoryID: vine.string().trim().minLength(1),
     fluxID: vine.string().trim().minLength(1),
-    taxID: vine.string().trim().minLength(1),
+    taxID: vine.string().trim().minLength(1).optional(),
   }),
 )
 
-export const UpdateProductValidator = vine.compile(
+export const UpdateProductValidator = vine.create(
   vine.object({
     productName: vine.string().trim().minLength(1).maxLength(255),
     categoryID: vine.string().trim().minLength(1),
     originID: vine.string().trim().minLength(1),
     territoryID: vine.string().trim().minLength(1),
     fluxID: vine.string().trim().minLength(1),
-    taxID: vine.string().trim().minLength(1),
+    taxID: vine.string().trim().minLength(1).optional(),
   }),
 )

--- a/apps/api/app/validators/GetProductTaxeValidator.ts
+++ b/apps/api/app/validators/GetProductTaxeValidator.ts
@@ -1,13 +1,9 @@
-import { OriginData, TerritoryData } from "@taxdom/types"
 import vine from "@vinejs/vine"
 
-const Origin = OriginData.map((o) => o.name)
-const Territory = TerritoryData.map((t) => t.name)
-
-export const GetProductTaxeValidator = vine.compile(
+export const GetProductTaxeValidator = vine.create(
   vine.object({
     product: vine.string().trim().escape(),
-    origin: vine.enum(Origin),
-    territory: vine.enum(Territory),
+    origin: vine.string(),
+    territory: vine.string(),
   }),
 )

--- a/apps/api/app/validators/OriginValidator.ts
+++ b/apps/api/app/validators/OriginValidator.ts
@@ -1,0 +1,17 @@
+import vine from "@vinejs/vine"
+
+export const createOriginValidator = vine.create(
+  vine.object({
+    originName: vine.string().trim().minLength(1).maxLength(100),
+    isEU: vine.boolean(),
+    available: vine.boolean().optional(),
+  }),
+)
+
+export const updateOriginValidator = vine.create(
+  vine.object({
+    originName: vine.string().trim().minLength(1).maxLength(100).optional(),
+    isEU: vine.boolean().optional(),
+    available: vine.boolean().optional(),
+  }),
+)

--- a/apps/api/app/validators/SearchProductsValidator.ts
+++ b/apps/api/app/validators/SearchProductsValidator.ts
@@ -1,7 +1,7 @@
 import vine from "@vinejs/vine"
 
-export const SearchProductsValidator = vine.compile(
+export const SearchProductsValidator = vine.create(
   vine.object({
-    name: vine.string().alphaNumeric(),
+    name: vine.string().trim().minLength(1).maxLength(255),
   }),
 )

--- a/apps/api/app/validators/TerritoryValidator.ts
+++ b/apps/api/app/validators/TerritoryValidator.ts
@@ -1,0 +1,14 @@
+import vine from "@vinejs/vine"
+
+export const createTerritoryValidator = vine.create(
+  vine.object({
+    territoryName: vine.string().trim().minLength(1).maxLength(100),
+  }),
+)
+
+export const updateTerritoryValidator = vine.create(
+  vine.object({
+    territoryName: vine.string().trim().minLength(1).maxLength(100).optional(),
+    available: vine.boolean().optional(),
+  }),
+)

--- a/apps/api/app/validators/TransporterRulesValidator.ts
+++ b/apps/api/app/validators/TransporterRulesValidator.ts
@@ -62,3 +62,7 @@ export const SaveAllBodySchema = vine.object({
   edges: vine.array(FlowEdgeSchema).maxLength(1000),
   rules: vine.array(FeeRuleSchema).maxLength(200),
 })
+
+export const saveFlowValidator = vine.create(SaveFlowBodySchema)
+export const saveRulesValidator = vine.create(SaveRulesBodySchema)
+export const saveAllValidator = vine.create(SaveAllBodySchema)

--- a/apps/api/app/validators/TransporterValidator.ts
+++ b/apps/api/app/validators/TransporterValidator.ts
@@ -1,10 +1,14 @@
 import vine from "@vinejs/vine"
 
-export const CreateTransporterValidator = vine.create({
-  transporterName: vine.string().trim().minLength(1).maxLength(255),
-})
+export const CreateTransporterValidator = vine.create(
+  vine.object({
+    transporterName: vine.string().trim().minLength(1).maxLength(255),
+  }),
+)
 
-export const UpdateTransporterValidator = vine.create({
-  transporterName: vine.string().trim().minLength(1).maxLength(255).optional(),
-  available: vine.boolean().optional(),
-})
+export const UpdateTransporterValidator = vine.create(
+  vine.object({
+    transporterName: vine.string().trim().minLength(1).maxLength(255).optional(),
+    available: vine.boolean().optional(),
+  }),
+)


### PR DESCRIPTION
### Improve validation

`request.validateUsing()` automatically extracts the body and handles errors via the global exception handler. Using `.validate()` manually is fine for non-HTTP contexts (jobs, commands), but for HTTP controllers, it’s unnecessary extra code.

 `vine.create()` is deprecated in favor of `vine.compile()`
 
 ### Remove enum select validation

The [CalculateParcelTaxeValidator ](https://github.com/zeis974/TaxDOM/blob/main/apps/api/app/validators/CalculateParcelTaxeValidator.ts#L8) and [GetProductTaxeValidator ](https://github.com/zeis974/TaxDOM/blob/main/apps/api/app/validators/GetProductTaxeValidator.ts#L7) validators import missing `OriginData`, `TerritoryData`, and `TransporterData` from **@taxdom/types**. These imports are used solely to create `vine.enum()` objects based on the names of each element.
 
However, this validation is inconsistent and serves no useful purpose; the validation no longer checks whether a list is part of an enum, but instead verifies that it is indeed a string.

```diff
-territory: vine.enum(Territory),
-transporter: vine.enum(Transporter),
+territory: vine.string(),
+transporter: vine.string(),
``` 