### PR TITLE
refactor: remove `flux` parameters from application

### DIFF
--- a/apps/api/app/controllers/ProductsController.ts
+++ b/apps/api/app/controllers/ProductsController.ts
@@ -7,7 +7,6 @@ import { v7 as uuidv7 } from "uuid"
 import { db } from "#config/database"
 import {
   categories,
-  flux,
   origins,
   products,
   taxes,
@@ -26,9 +25,6 @@ const productRelations = {
   territory: {
     columns: { territoryID: true, territoryName: true },
   },
-  flux: {
-    columns: { fluxID: true, fluxName: true },
-  },
   tax: {
     columns: { taxID: true, tva: true, om: true, omr: true },
   },
@@ -40,7 +36,6 @@ function mapProduct(product: {
   category: { categoryID: string; categoryName: string }
   origin: { originID: string; originName: string; isEU: boolean }
   territory: { territoryID: string; territoryName: string }
-  flux: { fluxID: string; fluxName: string }
   tax: { taxID: string; tva: number; om: number; omr: number }
   createdAt: Date | null
   updatedAt: Date | null
@@ -60,10 +55,6 @@ function mapProduct(product: {
     territory: {
       territoryID: product.territory.territoryID,
       territoryName: product.territory.territoryName,
-    },
-    flux: {
-      fluxID: product.flux.fluxID,
-      fluxName: product.flux.fluxName,
     },
     tax: {
       taxID: product.tax.taxID,
@@ -138,21 +129,6 @@ export default class ProductsController {
   }
 
   /**
-   * List all flux
-   */
-  async listFlux() {
-    try {
-      const allFlux = await db.query.flux.findMany({
-        orderBy: (flux, { asc }) => [asc(flux.fluxName)],
-      })
-      return allFlux
-    } catch (err) {
-      logger.error({ err }, "Cannot get flux list")
-      return []
-    }
-  }
-
-  /**
    * List all taxes
    */
   async listTaxes() {
@@ -189,17 +165,15 @@ export default class ProductsController {
   async store({ request, response }: HttpContext) {
     try {
       const validatedData = await request.validateUsing(CreateProductValidator)
-      const { productName, categoryID, originID, territoryID, fluxID, taxID } = validatedData
+      const { productName, categoryID, originID, territoryID, taxID } = validatedData
 
-      // Verify all FK entities exist
-      const [existingCategory, existingOrigin, existingTerritory, existingFlux, existingTax] =
-        await Promise.all([
+      const [existingCategory, existingOrigin, existingTerritory] = await Promise.all(
+        [
           db.query.categories.findFirst({ where: eq(categories.categoryID, categoryID) }),
           db.query.origins.findFirst({ where: eq(origins.originID, originID) }),
           db.query.territories.findFirst({ where: eq(territories.territoryID, territoryID) }),
-          db.query.flux.findFirst({ where: eq(flux.fluxID, fluxID) }),
-          db.query.taxes.findFirst({ where: eq(taxes.taxID, taxID) }),
-        ])
+        ],
+      )
 
       if (!existingCategory) {
         return response.badRequest({ error: "La catégorie spécifiée n'existe pas" })
@@ -210,11 +184,16 @@ export default class ProductsController {
       if (!existingTerritory) {
         return response.badRequest({ error: "Le territoire spécifié n'existe pas" })
       }
-      if (!existingFlux) {
-        return response.badRequest({ error: "Le flux spécifié n'existe pas" })
-      }
+      const derivedTaxID = existingCategory.taxID
+      const existingTax = await db.query.taxes.findFirst({ where: eq(taxes.taxID, derivedTaxID) })
       if (!existingTax) {
-        return response.badRequest({ error: "La taxe spécifiée n'existe pas" })
+        return response.badRequest({ error: "La taxe associée à la catégorie n'existe pas" })
+      }
+      if (taxID && taxID !== derivedTaxID) {
+        logger.warn(
+          { providedTaxID: taxID, derivedTaxID, categoryID },
+          "[PRODUCTS]: Ignoring mismatched taxID from payload and using category tax",
+        )
       }
 
       // Check for duplicate product name
@@ -234,8 +213,7 @@ export default class ProductsController {
         categoryID,
         originID,
         territoryID,
-        fluxID,
-        taxID,
+        taxID: derivedTaxID,
       })
 
       const createdProduct = await db.query.products.findFirst({
@@ -301,27 +279,15 @@ export default class ProductsController {
       }
 
       const validatedData = await request.validateUsing(UpdateProductValidator)
-      const { productName, categoryID, originID, territoryID, fluxID, taxID } = validatedData
+      const { productName, categoryID, originID, territoryID, taxID } = validatedData
 
-      // Check for duplicate product name (excluding current product)
-      const duplicateProduct = await db.query.products.findFirst({
-        where: (products, { eq, and, ne }) =>
-          and(eq(products.productName, productName.trim()), ne(products.productID, productId)),
-      })
-
-      if (duplicateProduct) {
-        return response.badRequest({ error: "Un produit avec ce nom existe déjà" })
-      }
-
-      // Verify all FK entities exist
-      const [existingCategory, existingOrigin, existingTerritory, existingFlux, existingTax] =
-        await Promise.all([
+      const [existingCategory, existingOrigin, existingTerritory] = await Promise.all(
+        [
           db.query.categories.findFirst({ where: eq(categories.categoryID, categoryID) }),
           db.query.origins.findFirst({ where: eq(origins.originID, originID) }),
           db.query.territories.findFirst({ where: eq(territories.territoryID, territoryID) }),
-          db.query.flux.findFirst({ where: eq(flux.fluxID, fluxID) }),
-          db.query.taxes.findFirst({ where: eq(taxes.taxID, taxID) }),
-        ])
+        ],
+      )
 
       if (!existingCategory) {
         return response.badRequest({ error: "La catégorie spécifiée n'existe pas" })
@@ -332,11 +298,16 @@ export default class ProductsController {
       if (!existingTerritory) {
         return response.badRequest({ error: "Le territoire spécifié n'existe pas" })
       }
-      if (!existingFlux) {
-        return response.badRequest({ error: "Le flux spécifié n'existe pas" })
-      }
+      const derivedTaxID = existingCategory.taxID
+      const existingTax = await db.query.taxes.findFirst({ where: eq(taxes.taxID, derivedTaxID) })
       if (!existingTax) {
-        return response.badRequest({ error: "La taxe spécifiée n'existe pas" })
+        return response.badRequest({ error: "La taxe associée à la catégorie n'existe pas" })
+      }
+      if (taxID && taxID !== derivedTaxID) {
+        logger.warn(
+          { providedTaxID: taxID, derivedTaxID, categoryID, productId },
+          "[PRODUCTS]: Ignoring mismatched taxID from payload and using category tax",
+        )
       }
 
       await db
@@ -346,8 +317,7 @@ export default class ProductsController {
           categoryID,
           originID,
           territoryID,
-          fluxID,
-          taxID,
+          taxID: derivedTaxID,
         })
         .where(eq(products.productID, productId))
 

--- a/apps/api/app/routes/admin/products.ts
+++ b/apps/api/app/routes/admin/products.ts
@@ -7,7 +7,6 @@ export default function registerProductsRoutes(router: HttpRouterService) {
   router.get("/products/count", [ProductsController, "count"])
   router.get("/products/recent", [ProductsController, "recent"])
   router.get("/products/distribution", [ProductsController, "distribution"])
-  router.get("/products/flux", [ProductsController, "listFlux"])
   router.get("/products/taxes", [ProductsController, "listTaxes"])
   router.resource("products", ProductsController).apiOnly()
 }

--- a/apps/api/app/validators/CreateProductValidator.ts
+++ b/apps/api/app/validators/CreateProductValidator.ts
@@ -6,7 +6,6 @@ export const CreateProductValidator = vine.create(
     categoryID: vine.string().trim().minLength(1),
     originID: vine.string().trim().minLength(1),
     territoryID: vine.string().trim().minLength(1),
-    fluxID: vine.string().trim().minLength(1),
     taxID: vine.string().trim().minLength(1).optional(),
   }),
 )
@@ -17,7 +16,6 @@ export const UpdateProductValidator = vine.create(
     categoryID: vine.string().trim().minLength(1),
     originID: vine.string().trim().minLength(1),
     territoryID: vine.string().trim().minLength(1),
-    fluxID: vine.string().trim().minLength(1),
     taxID: vine.string().trim().minLength(1).optional(),
   }),
 )

--- a/apps/api/database/schema.ts
+++ b/apps/api/database/schema.ts
@@ -1,8 +1,8 @@
 import { relations } from "drizzle-orm"
 import {
   boolean,
+  decimal,
   index,
-  integer,
   pgTable,
   primaryKey,
   timestamp,
@@ -21,11 +21,6 @@ export const categories = pgTable(
   (table) => [index("categories_taxID_idx").on(table.taxID)],
 )
 
-export const flux = pgTable("flux", {
-  fluxID: varchar("flux_id").notNull().primaryKey(),
-  fluxName: varchar("flux_name").notNull(),
-})
-
 export const origins = pgTable("origins", {
   originID: varchar("origin_id").notNull().primaryKey(),
   originName: varchar("origin_name").notNull().unique(),
@@ -35,9 +30,9 @@ export const origins = pgTable("origins", {
 
 export const taxes = pgTable("taxes", {
   taxID: varchar("tax_id").notNull().primaryKey(),
-  tva: integer("tva").notNull(),
-  om: integer("om").notNull(),
-  omr: integer("omr").notNull(),
+  tva: decimal("tva", { precision: 10, scale: 2 }).notNull(),
+  om: decimal("om", { precision: 10, scale: 2 }).notNull(),
+  omr: decimal("omr", { precision: 10, scale: 2 }).notNull(),
 })
 
 export const territories = pgTable("territories", {
@@ -66,9 +61,6 @@ export const products = pgTable(
     territoryID: varchar("territory_id")
       .notNull()
       .references(() => territories.territoryID),
-    fluxID: varchar("flux_id")
-      .notNull()
-      .references(() => flux.fluxID),
     taxID: varchar("tax_id")
       .notNull()
       .references(() => taxes.taxID),
@@ -81,7 +73,6 @@ export const products = pgTable(
     index("products_categoryID_idx").on(table.categoryID),
     index("products_originID_idx").on(table.originID),
     index("products_territoryID_idx").on(table.territoryID),
-    index("products_fluxID_idx").on(table.fluxID),
     index("products_taxID_idx").on(table.taxID),
   ],
 )
@@ -112,10 +103,6 @@ export const CategoriesRelations = relations(categories, ({ one, many }) => ({
   products: many(products),
 }))
 
-export const FluxRelations = relations(flux, ({ many }) => ({
-  products: many(products),
-}))
-
 export const OriginsRelations = relations(origins, ({ many }) => ({
   products: many(products),
 }))
@@ -141,10 +128,6 @@ export const ProductsRelations = relations(products, ({ one, many }) => ({
   territory: one(territories, {
     fields: [products.territoryID],
     references: [territories.territoryID],
-  }),
-  flux: one(flux, {
-    fields: [products.fluxID],
-    references: [flux.fluxID],
   }),
   tax: one(taxes, {
     fields: [products.taxID],

--- a/apps/dashboard/src/components/Dashboard/Products/AddProduct/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Products/AddProduct/index.tsx
@@ -15,7 +15,6 @@ export default function AddProduct() {
   const [categoryID, setCategoryID] = useState("")
   const [originID, setOriginID] = useState("")
   const [territoryID, setTerritoryID] = useState("")
-  const [fluxID, setFluxID] = useState("")
 
   const inputId = useId()
   const queryClient = useQueryClient()
@@ -27,7 +26,6 @@ export default function AddProduct() {
       categoryID: string
       originID: string
       territoryID: string
-      fluxID: string
     }) => client.api.products.store({ body }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["products"] })
@@ -39,14 +37,13 @@ export default function AddProduct() {
     },
   })
 
-  const isFormValid = productName.trim() && categoryID && originID && territoryID && fluxID
+  const isFormValid = productName.trim() && categoryID && originID && territoryID
 
   const resetForm = () => {
     setProductName("")
     setCategoryID("")
     setOriginID("")
     setTerritoryID("")
-    setFluxID("")
   }
 
   const handleClose = () => {
@@ -62,7 +59,6 @@ export default function AddProduct() {
       categoryID,
       originID,
       territoryID,
-      fluxID,
     })
   }
 
@@ -131,16 +127,6 @@ export default function AddProduct() {
               onChange={(val) => {
                 const found = formOptions?.territories.find((t) => t.name === val)
                 if (found) setTerritoryID(found.value ?? found.name)
-              }}
-              disabled={isLoading}
-            />
-            <BaseSelect
-              label="Flux *"
-              options={formOptions?.flux ?? []}
-              value={formOptions?.flux.find((f) => f.value === fluxID)?.name ?? ""}
-              onChange={(val) => {
-                const found = formOptions?.flux.find((f) => f.name === val)
-                if (found) setFluxID(found.value ?? found.name)
               }}
               disabled={isLoading}
             />

--- a/apps/dashboard/src/components/Dashboard/Products/ProductCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Products/ProductCard/index.tsx
@@ -48,7 +48,6 @@ export default function ProductCard({ product, editable = false }: Props) {
   const [categoryID, setCategoryID] = useState(product.category.categoryID)
   const [originID, setOriginID] = useState(product.origin.originID)
   const [territoryID, setTerritoryID] = useState(product.territory.territoryID)
-  const [fluxID, setFluxID] = useState(product.flux.fluxID)
 
   const queryClient = useQueryClient()
 
@@ -60,7 +59,6 @@ export default function ProductCard({ product, editable = false }: Props) {
         categoryID: string
         originID: string
         territoryID: string
-        fluxID: string
         taxID: string
       }
     }) => client.api.products.update(vars),
@@ -87,8 +85,8 @@ export default function ProductCard({ product, editable = false }: Props) {
   })
 
   const isFormValid = useMemo(
-    () => Boolean(productName.trim() && categoryID && originID && territoryID && fluxID),
-    [productName, categoryID, originID, territoryID, fluxID],
+    () => Boolean(productName.trim() && categoryID && originID && territoryID),
+    [productName, categoryID, originID, territoryID],
   )
 
   const handleCardClick = () => {
@@ -97,7 +95,6 @@ export default function ProductCard({ product, editable = false }: Props) {
     setCategoryID(product.category.categoryID)
     setOriginID(product.origin.originID)
     setTerritoryID(product.territory.territoryID)
-    setFluxID(product.flux.fluxID)
     drawer.openDrawer()
   }
 
@@ -118,7 +115,6 @@ export default function ProductCard({ product, editable = false }: Props) {
         categoryID,
         originID,
         territoryID,
-        fluxID,
         taxID: product.tax?.taxID ?? "",
       },
     })
@@ -140,7 +136,7 @@ export default function ProductCard({ product, editable = false }: Props) {
         </BadgeContainer>
       </CardHeader>
       <CardInfo>
-        {product.origin.originName} • {product.territory.territoryName} • {product.flux.fluxName}
+        {product.origin.originName} • {product.territory.territoryName}
       </CardInfo>
     </>
   )
@@ -189,9 +185,9 @@ export default function ProductCard({ product, editable = false }: Props) {
                     </FormGrid>
                   </DrawerSection>
                   <DrawerSection>
-                    <DrawerSectionTitle>Provenance & Flux</DrawerSectionTitle>
+                    <DrawerSectionTitle>Provenance</DrawerSectionTitle>
                     <DrawerSectionDescription>
-                      Origine, flux et territoire du produit.
+                      Origine et territoire du produit.
                     </DrawerSectionDescription>
                     <FormGrid>
                       <BaseSelect
@@ -223,15 +219,6 @@ export default function ProductCard({ product, editable = false }: Props) {
                         onChange={(val) => {
                           const found = formOptions?.territories.find((t) => t.name === val)
                           if (found) setTerritoryID(found.value ?? found.name)
-                        }}
-                      />
-                      <BaseSelect
-                        label="Flux"
-                        options={formOptions?.flux ?? []}
-                        value={formOptions?.flux.find((f) => f.value === fluxID)?.name ?? ""}
-                        onChange={(val) => {
-                          const found = formOptions?.flux.find((f) => f.name === val)
-                          if (found) setFluxID(found.value ?? found.name)
                         }}
                       />
                     </FormGrid>

--- a/apps/dashboard/src/hooks/useProductFormOptions.ts
+++ b/apps/dashboard/src/hooks/useProductFormOptions.ts
@@ -14,11 +14,10 @@ export function useProductFormOptions() {
   return useQuery({
     queryKey: ["productFormOptions"],
     queryFn: async () => {
-      const [categoriesRaw, originsRaw, territoriesRaw, fluxRaw, taxesRaw] = await Promise.all([
+      const [categoriesRaw, originsRaw, territoriesRaw, taxesRaw] = await Promise.all([
         client.api.categories.index({}),
         client.api.origins.index({}),
         client.api.territories.index({}),
-        client.api.products.listFlux({}),
         client.api.products.listTaxes({}),
       ])
 
@@ -40,14 +39,9 @@ export function useProductFormOptions() {
         available: t.available,
       }))
 
-      const flux: FormOption[] = fluxRaw.map((f) => ({
-        name: f.fluxName,
-        value: f.fluxID,
-      }))
-
       const taxes = taxesRaw
 
-      return { categories, origins, territories, flux, taxes }
+      return { categories, origins, territories, taxes }
     },
     staleTime: 5 * 60 * 1000,
   })

--- a/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
+++ b/apps/web/src/components/services/TaxSimulator/TaxSimulatorForm/index.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import type { TaxSimulatorFormLabel } from "../types"
-
 import { mergeForm } from "@tanstack/react-form"
 import { initialFormState, useTransform } from "@tanstack/react-form-nextjs"
 import { useQuery } from "@tanstack/react-query"
@@ -15,17 +13,15 @@ import { territoryQueryOptions } from "@/lib/territories"
 import Turnstile from "@/lib/Turnstile"
 import { useTaxSimulatorStore } from "@/providers/TaxSimulatorStoreProvider"
 
-import { Radio, Select } from "@/components/Forms"
+import { Select } from "@/components/Forms"
 
 import { CaptchaContainer } from "./TaxSimulatorForm.styled"
 
 export default function TaxSimulatorForm() {
   const [state, action] = useActionState(getProductTaxes, initialFormState)
 
-  const hasResult = useTaxSimulatorStore((s) => s.hasResult)
   const setHasResult = useTaxSimulatorStore((s) => s.setHasResult)
   const setResult = useTaxSimulatorStore((s) => s.setResult)
-  const setSelectedCountry = useTaxSimulatorStore((s) => s.setSelectedCountry)
 
   useEffect(() => {
     if (state.taxes) {
@@ -70,10 +66,9 @@ export default function TaxSimulatorForm() {
         name="territory"
         label="Territoire d'application"
         placeholder="Réunion"
-        options={territoryOptions.map((t) => ({ name: t.territoryName, value: t.territoryID }))}
+        options={territoryOptions}
       />
       <CaptchaContainer>
-        <Radio {...{ form }} name="flux" label="Flux" options={["import", "export"]} disabled />
         <Turnstile />
       </CaptchaContainer>
       <form.AppForm>

--- a/apps/web/src/components/services/TaxSimulator/types.ts
+++ b/apps/web/src/components/services/TaxSimulator/types.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 
 export const TaxSimulatorFormSchema = z.object({
-  flux: z.enum(["import", "export"]),
   origin: z.string(),
   product: z.string(),
   territory: z.string(),

--- a/apps/web/src/shared/formOpts.ts
+++ b/apps/web/src/shared/formOpts.ts
@@ -22,7 +22,6 @@ export const parcelFormOpts = formOptions({
 export const taxFormOpts = formOptions({
   defaultValues: {
     "cf-turnstile-response": "",
-    flux: "import" as "import" | "export",
     origin: "",
     product: "",
     territory: "REUNION",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -71,6 +71,8 @@ export type TransporterWithRules = Transporter & {
 export type Category = {
   categoryID: string
   categoryName: string
+  taxID: string
+  relatedProducts: number
   taxes?: {
     tva: number
     om: number
@@ -93,10 +95,6 @@ export type Product = {
   territory: {
     territoryID: string
     territoryName: string
-  }
-  flux: {
-    fluxID: string
-    fluxName: string
   }
   tax: {
     taxID: string


### PR DESCRIPTION
Since the application only supports the **import flow**, the flux field was unnecessary overhead. The origin (**EU**/**non-EU**) and territory already implicitly determine the flow direction, so removing it simplifies both the data model and the UI without any loss of functionality.