### PR TITLE
feat: integrate `@tuyau/react-query` for type-safe TanStack Query APIs

### DIFF
--- a/apps/api/.adonisjs/client/registry/index.ts
+++ b/apps/api/.adonisjs/client/registry/index.ts
@@ -263,17 +263,6 @@ const routes = {
     ],
     types: placeholder as Registry["products.distribution"]["types"],
   },
-  "products.list_flux": {
-    methods: ["GET", "HEAD"],
-    pattern: "/v1/admin/products/flux",
-    tokens: [
-      { old: "/v1/admin/products/flux", type: 0, val: "v1", end: "" },
-      { old: "/v1/admin/products/flux", type: 0, val: "admin", end: "" },
-      { old: "/v1/admin/products/flux", type: 0, val: "products", end: "" },
-      { old: "/v1/admin/products/flux", type: 0, val: "flux", end: "" },
-    ],
-    types: placeholder as Registry["products.list_flux"]["types"],
-  },
   "products.list_taxes": {
     methods: ["GET", "HEAD"],
     pattern: "/v1/admin/products/taxes",

--- a/apps/api/.adonisjs/client/registry/schema.d.ts
+++ b/apps/api/.adonisjs/client/registry/schema.d.ts
@@ -441,22 +441,6 @@ export interface Registry {
       >
     }
   }
-  "products.list_flux": {
-    methods: ["GET", "HEAD"]
-    pattern: "/v1/admin/products/flux"
-    types: {
-      body: {}
-      paramsTuple: []
-      params: {}
-      query: {}
-      response: ExtractResponse<
-        Awaited<ReturnType<import("#controllers/ProductsController").default["listFlux"]>>
-      >
-      errorResponse: ExtractErrorResponse<
-        Awaited<ReturnType<import("#controllers/ProductsController").default["listFlux"]>>
-      >
-    }
-  }
   "products.list_taxes": {
     methods: ["GET", "HEAD"]
     pattern: "/v1/admin/products/taxes"
@@ -817,72 +801,48 @@ export interface Registry {
     methods: ["POST"]
     pattern: "/v1/admin/transporters/:transporterId/rules/flow"
     types: {
-      body: ExtractBody<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveFlowValidator>
-      >
+      body: {}
       paramsTuple: [ParamValue]
       params: { transporterId: ParamValue }
-      query: ExtractQuery<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveFlowValidator>
-      >
+      query: {}
       response: ExtractResponse<
         Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveFlow"]>>
       >
-      errorResponse:
-        | ExtractErrorResponse<
-            Awaited<
-              ReturnType<import("#controllers/TransporterRulesController").default["saveFlow"]>
-            >
-          >
-        | { status: 422; response: { errors: SimpleError[] } }
+      errorResponse: ExtractErrorResponse<
+        Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveFlow"]>>
+      >
     }
   }
   "transporter_rules.save_rules": {
     methods: ["POST"]
     pattern: "/v1/admin/transporters/:transporterId/rules/fees"
     types: {
-      body: ExtractBody<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveRulesValidator>
-      >
+      body: {}
       paramsTuple: [ParamValue]
       params: { transporterId: ParamValue }
-      query: ExtractQuery<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveRulesValidator>
-      >
+      query: {}
       response: ExtractResponse<
         Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveRules"]>>
       >
-      errorResponse:
-        | ExtractErrorResponse<
-            Awaited<
-              ReturnType<import("#controllers/TransporterRulesController").default["saveRules"]>
-            >
-          >
-        | { status: 422; response: { errors: SimpleError[] } }
+      errorResponse: ExtractErrorResponse<
+        Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveRules"]>>
+      >
     }
   }
   "transporter_rules.save_all": {
     methods: ["POST"]
     pattern: "/v1/admin/transporters/:transporterId/rules"
     types: {
-      body: ExtractBody<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveAllValidator>
-      >
+      body: {}
       paramsTuple: [ParamValue]
       params: { transporterId: ParamValue }
-      query: ExtractQuery<
-        InferInput<typeof import("#validators/TransporterRulesValidator").saveAllValidator>
-      >
+      query: {}
       response: ExtractResponse<
         Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveAll"]>>
       >
-      errorResponse:
-        | ExtractErrorResponse<
-            Awaited<
-              ReturnType<import("#controllers/TransporterRulesController").default["saveAll"]>
-            >
-          >
-        | { status: 422; response: { errors: SimpleError[] } }
+      errorResponse: ExtractErrorResponse<
+        Awaited<ReturnType<import("#controllers/TransporterRulesController").default["saveAll"]>>
+      >
     }
   }
 }

--- a/apps/api/.adonisjs/client/registry/tree.d.ts
+++ b/apps/api/.adonisjs/client/registry/tree.d.ts
@@ -48,7 +48,6 @@ export interface ApiDefinition {
     count: (typeof routes)["products.count"]
     recent: (typeof routes)["products.recent"]
     distribution: (typeof routes)["products.distribution"]
-    listFlux: (typeof routes)["products.list_flux"]
     listTaxes: (typeof routes)["products.list_taxes"]
     index: (typeof routes)["products.index"]
     store: (typeof routes)["products.store"]

--- a/apps/api/.adonisjs/server/routes.d.ts
+++ b/apps/api/.adonisjs/server/routes.d.ts
@@ -28,7 +28,6 @@ export type ScannedRoutes = {
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
     "products.index": { paramsTuple?: []; params?: {} }
     "products.store": { paramsTuple?: []; params?: {} }
@@ -79,7 +78,6 @@ export type ScannedRoutes = {
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
     "products.index": { paramsTuple?: []; params?: {} }
     "products.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }
@@ -109,7 +107,6 @@ export type ScannedRoutes = {
     "products.count": { paramsTuple?: []; params?: {} }
     "products.recent": { paramsTuple?: []; params?: {} }
     "products.distribution": { paramsTuple?: []; params?: {} }
-    "products.list_flux": { paramsTuple?: []; params?: {} }
     "products.list_taxes": { paramsTuple?: []; params?: {} }
     "products.index": { paramsTuple?: []; params?: {} }
     "products.show": { paramsTuple: [ParamValue]; params: { id: ParamValue } }

--- a/apps/api/app/controllers/OriginsController.ts
+++ b/apps/api/app/controllers/OriginsController.ts
@@ -6,6 +6,7 @@ import { v7 as uuidv7 } from "uuid"
 
 import { db } from "#config/database"
 import { origins, products } from "#database/schema"
+import { createOriginValidator, updateOriginValidator } from "#validators/OriginValidator"
 
 export default class OriginsController {
   /**
@@ -118,32 +119,10 @@ export default class OriginsController {
    */
   async store({ request, response }: HttpContext) {
     try {
-      const { originName, isEU, available, isActive } = request.only([
-        "originName",
-        "isEU",
-        "available",
-        "isActive",
-      ]) as {
-        originName?: unknown
-        isEU?: unknown
-        available?: unknown
-        isActive?: unknown
-      }
+      const validatedData = await request.validateUsing(createOriginValidator)
+      const { originName, isEU, available } = validatedData
 
-      if (!originName || typeof originName !== "string" || originName.trim().length === 0) {
-        return response.status(400).json({
-          error: "Le nom de l'origine est requis",
-        })
-      }
-
-      if (typeof isEU !== "boolean") {
-        return response.status(400).json({
-          error: "Le statut UE est requis",
-        })
-      }
-
-      const resolvedAvailable =
-        typeof available === "boolean" ? available : typeof isActive === "boolean" ? isActive : true
+      const resolvedAvailable = available ?? true
 
       const trimmedName = originName.trim().toUpperCase()
       const originID = uuidv7()
@@ -189,16 +168,17 @@ export default class OriginsController {
       const originIdParam: string = params.id
       if (!originIdParam) return response.status(400).json({ error: "Paramètre manquant" })
 
-      const { originName, available, isEU } = request.only(["originName", "available", "isEU"])
+      const validatedData = await request.validateUsing(updateOriginValidator)
+      const { originName, available, isEU } = validatedData
 
       const updateData: Partial<typeof origins.$inferInsert> = {}
-      if (typeof originName === "string" && originName.trim().length > 0) {
+      if (originName) {
         updateData.originName = originName.trim().toUpperCase()
       }
-      if (typeof available === "boolean") {
+      if (available !== undefined) {
         updateData.available = available
       }
-      if (typeof isEU === "boolean") {
+      if (isEU !== undefined) {
         updateData.isEU = isEU
       }
 

--- a/apps/api/app/validators/CreateProductValidator.ts
+++ b/apps/api/app/validators/CreateProductValidator.ts
@@ -3,19 +3,18 @@ import vine from "@vinejs/vine"
 export const CreateProductValidator = vine.create(
   vine.object({
     productName: vine.string().trim().minLength(1).maxLength(255),
-    categoryID: vine.string().trim().minLength(1),
-    originID: vine.string().trim().minLength(1),
-    territoryID: vine.string().trim().minLength(1),
-    taxID: vine.string().trim().minLength(1).optional(),
+    categoryID: vine.string().uuid(),
+    originID: vine.string().uuid(),
+    territoryID: vine.string().uuid(),
   }),
 )
 
 export const UpdateProductValidator = vine.create(
   vine.object({
     productName: vine.string().trim().minLength(1).maxLength(255),
-    categoryID: vine.string().trim().minLength(1),
-    originID: vine.string().trim().minLength(1),
-    territoryID: vine.string().trim().minLength(1),
-    taxID: vine.string().trim().minLength(1).optional(),
+    categoryID: vine.string().uuid(),
+    originID: vine.string().uuid(),
+    territoryID: vine.string().uuid(),
+    taxID: vine.string().uuid().optional(),
   }),
 )

--- a/apps/api/app/validators/TerritoryValidator.ts
+++ b/apps/api/app/validators/TerritoryValidator.ts
@@ -3,6 +3,7 @@ import vine from "@vinejs/vine"
 export const createTerritoryValidator = vine.create(
   vine.object({
     territoryName: vine.string().trim().minLength(1).maxLength(100),
+    available: vine.boolean().optional(),
   }),
 )
 

--- a/apps/api/app/validators/TransporterValidator.ts
+++ b/apps/api/app/validators/TransporterValidator.ts
@@ -3,6 +3,7 @@ import vine from "@vinejs/vine"
 export const CreateTransporterValidator = vine.create(
   vine.object({
     transporterName: vine.string().trim().minLength(1).maxLength(255),
+    available: vine.boolean().optional(),
   }),
 )
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-virtual": "3.13.24",
     "@taxdom/api": "workspace:*",
     "@tuyau/core": "1.2.2",
+    "@tuyau/react-query": "^1.1.0",
     "@xyflow/react": "12.10.2",
     "better-auth": "1.6.9",
     "motion": "12.38.0",

--- a/apps/dashboard/src/components/Dashboard/Categories/AddCategory/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Categories/AddCategory/index.tsx
@@ -3,14 +3,9 @@ import { useId, useState } from "react"
 import { toast } from "sonner"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import Modal from "@/components/Modal"
-import Button from "@/components/ui/Button"
-import { client } from "@/lib/api"
-import {
-  AddCategoryBtn,
-  AddCategoryContainer,
-  CategoryActions,
-  ErrorContainer,
-} from "./AddCategory.styled"
+import ModalCard from "@/components/Modal/ModalCard"
+import { api } from "@/lib/api"
+import { AddCategoryBtn, ErrorContainer } from "./AddCategory.styled"
 
 export default function AddCategory() {
   const [show, setShow] = useState(false)
@@ -26,18 +21,18 @@ export default function AddCategory() {
 
   const queryClient = useQueryClient()
 
-  const createMutation = useMutation({
-    mutationFn: (body: { categoryName: string; tva: number; om: number; omr: number }) =>
-      client.api.categories.store({ body }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-      toast.success("Catégorie créée avec succès")
-      handleClose()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la création")
-    },
-  })
+  const createMutation = useMutation(
+    api.categories.store.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.categories.index.pathKey() })
+        toast.success("Catégorie créée avec succès")
+        handleClose()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la création")
+      },
+    }),
+  )
 
   const isFormValid = categoryName.trim() && tva !== "" && om !== "" && omr !== ""
 
@@ -53,14 +48,15 @@ export default function AddCategory() {
     resetForm()
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = () => {
     if (!isFormValid) return
     createMutation.mutate({
-      categoryName: categoryName.trim(),
-      tva: Number(tva),
-      om: Number(om),
-      omr: Number(omr),
+      body: {
+        categoryName: categoryName.trim(),
+        tva: Number(tva),
+        om: Number(om),
+        omr: Number(omr),
+      },
     })
   }
 
@@ -72,10 +68,21 @@ export default function AddCategory() {
         Ajouter une catégorie
       </AddCategoryBtn>
       <Modal show={show} setShow={setShow}>
-        <AddCategoryContainer>
-          <h2>Ajouter une catégorie</h2>
-          <hr />
-          <form onSubmit={handleSubmit} autoComplete="off">
+        <ModalCard
+          title="Ajouter une catégorie"
+          onClose={handleClose}
+          submitLabel="Créer la catégorie"
+          onSubmit={handleSubmit}
+          submitDisabled={!isFormValid || createMutation.isPending}
+          submitLoading={createMutation.isPending}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmit()
+            }}
+            autoComplete="off"
+          >
             <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
               <InputContainer>
                 <label htmlFor={categoryNameID}>Nom de la catégorie *</label>
@@ -131,22 +138,15 @@ export default function AddCategory() {
                 </InputContainer>
               </div>
             </div>
-            <CategoryActions>
+            {errors.length > 0 && (
               <ErrorContainer>
-                {errors.length > 0 &&
-                  errors.map((error, index) => <span key={index}>{error}</span>)}
+                {errors.map((error, index) => (
+                  <span key={index}>{error}</span>
+                ))}
               </ErrorContainer>
-              <div style={{ display: "flex", gap: 8 }}>
-                <Button type="button" onClick={handleClose}>
-                  Annuler
-                </Button>
-                <Button type="submit" aria-disabled={!isFormValid || createMutation.isPending}>
-                  {createMutation.isPending ? "Création..." : "Créer la catégorie"}
-                </Button>
-              </div>
-            </CategoryActions>
+            )}
           </form>
-        </AddCategoryContainer>
+        </ModalCard>
       </Modal>
     </>
   )

--- a/apps/dashboard/src/components/Dashboard/Categories/CategoryCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Categories/CategoryCard/index.tsx
@@ -7,7 +7,7 @@ import TaxBar from "@/components/Dashboard/Categories/CategoriesList/TaxBar"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import Button from "@/components/ui/Button"
 import { useCardDrawer } from "@/hooks/useCardDrawer"
-import { client } from "@/lib/api"
+import { api } from "@/lib/api"
 import {
   ActionsGroup,
   Badge,
@@ -49,30 +49,31 @@ export default function CategoryCard({ category, onClick, editable = false }: Pr
 
   const queryClient = useQueryClient()
 
-  const updateMutation = useMutation({
-    mutationFn: (vars: { params: { id: string }; body: { categoryName: string; taxID: string } }) =>
-      client.api.categories.update(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-      toast.success("Catégorie mise à jour")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la mise à jour")
-    },
-  })
+  const updateMutation = useMutation(
+    api.categories.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.categories.index.pathKey() })
+        toast.success("Catégorie mise à jour")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la mise à jour")
+      },
+    }),
+  )
 
-  const deleteMutation = useMutation({
-    mutationFn: (vars: { params: { id: string } }) => client.api.categories.destroy(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["categories"] })
-      toast.success("Catégorie supprimée")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la suppression")
-    },
-  })
+  const deleteMutation = useMutation(
+    api.categories.destroy.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.categories.index.pathKey() })
+        toast.success("Catégorie supprimée")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la suppression")
+      },
+    }),
+  )
 
   const isFormValid = useMemo(() => Boolean(categoryName.trim()), [categoryName])
 

--- a/apps/dashboard/src/components/Dashboard/Origins/AddOrigin/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Origins/AddOrigin/index.tsx
@@ -3,9 +3,9 @@ import { useId, useState } from "react"
 import { toast } from "sonner"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import Modal from "@/components/Modal"
-import Button from "@/components/ui/Button"
-import { client } from "@/lib/api"
-import { AddOriginBtn, AddOriginContainer, ErrorContainer, OriginActions } from "./AddOrigin.styled"
+import ModalCard from "@/components/Modal/ModalCard"
+import { api } from "@/lib/api"
+import { AddOriginBtn, ErrorContainer } from "./AddOrigin.styled"
 
 export default function AddOrigin() {
   const [show, setShow] = useState(false)
@@ -15,18 +15,18 @@ export default function AddOrigin() {
   const originNameID = useId()
   const queryClient = useQueryClient()
 
-  const createMutation = useMutation({
-    mutationFn: (body: { originName: string; available: boolean; isEU: boolean }) =>
-      client.api.origins.store({ body }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["origins"] })
-      toast.success("Origine créée avec succès")
-      handleClose()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la création")
-    },
-  })
+  const createMutation = useMutation(
+    api.origins.store.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.origins.index.pathKey() })
+        toast.success("Origine créée avec succès")
+        handleClose()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la création")
+      },
+    }),
+  )
 
   const isFormValid = originName.trim() !== ""
 
@@ -41,10 +41,11 @@ export default function AddOrigin() {
     resetForm()
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = () => {
     if (!isFormValid) return
-    createMutation.mutate({ originName: originName.toUpperCase(), available, isEU })
+    createMutation.mutate({
+      body: { originName: originName.toUpperCase(), available, isEU },
+    })
   }
 
   const errors = createMutation.error ? ["Erreur lors de la création"] : []
@@ -55,10 +56,21 @@ export default function AddOrigin() {
         Ajouter une origine
       </AddOriginBtn>
       <Modal show={show} setShow={setShow}>
-        <AddOriginContainer>
-          <h2>Ajouter une origine</h2>
-          <hr />
-          <form onSubmit={handleSubmit} autoComplete="off">
+        <ModalCard
+          title="Ajouter une origine"
+          onClose={handleClose}
+          submitLabel="Créer l'origine"
+          onSubmit={handleSubmit}
+          submitDisabled={!isFormValid || createMutation.isPending}
+          submitLoading={createMutation.isPending}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmit()
+            }}
+            autoComplete="off"
+          >
             <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
               <InputContainer>
                 <label htmlFor={originNameID}>Nom de l'origine *</label>
@@ -95,22 +107,15 @@ export default function AddOrigin() {
                 </label>
               </div>
             </div>
-            <OriginActions>
+            {errors.length > 0 && (
               <ErrorContainer>
-                {errors.length > 0 &&
-                  errors.map((error, index) => <span key={index}>{error}</span>)}
+                {errors.map((error, index) => (
+                  <span key={index}>{error}</span>
+                ))}
               </ErrorContainer>
-              <div style={{ display: "flex", gap: 8 }}>
-                <Button type="button" onClick={handleClose}>
-                  Annuler
-                </Button>
-                <Button type="submit" aria-disabled={!isFormValid || createMutation.isPending}>
-                  {createMutation.isPending ? "Création..." : "Créer l'origine"}
-                </Button>
-              </div>
-            </OriginActions>
+            )}
           </form>
-        </AddOriginContainer>
+        </ModalCard>
       </Modal>
     </>
   )

--- a/apps/dashboard/src/components/Dashboard/Origins/OriginCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Origins/OriginCard/index.tsx
@@ -6,7 +6,7 @@ import { Drawer } from "vaul"
 import Button from "@/components/ui/Button"
 import { useCardDrawer } from "@/hooks/useCardDrawer"
 import { useResettableTimeout } from "@/hooks/useResettableTimeout"
-import { client } from "@/lib/api"
+import { api } from "@/lib/api"
 import {
   ActionsGroup,
   Badge,
@@ -53,32 +53,31 @@ export default function OriginCard({ origin, editable = false }: Props) {
 
   const queryClient = useQueryClient()
 
-  const updateMutation = useMutation({
-    mutationFn: (vars: {
-      params: { id: string }
-      body: { originName: string; available: boolean; isEU: boolean }
-    }) => client.api.origins.update(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["origins"] })
-      toast.success("Origine mise à jour")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la mise à jour")
-    },
-  })
+  const updateMutation = useMutation(
+    api.origins.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.origins.index.pathKey() })
+        toast.success("Origine mise à jour")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la mise à jour")
+      },
+    }),
+  )
 
-  const deleteMutation = useMutation({
-    mutationFn: (vars: { params: { id: string } }) => client.api.origins.destroy(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["origins"] })
-      toast.success("Origine supprimée")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la suppression")
-    },
-  })
+  const deleteMutation = useMutation(
+    api.origins.destroy.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.origins.index.pathKey() })
+        toast.success("Origine supprimée")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la suppression")
+      },
+    }),
+  )
 
   const isFormValid = useMemo(() => Boolean(originName.trim()), [originName])
 

--- a/apps/dashboard/src/components/Dashboard/Products/ProductCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Products/ProductCard/index.tsx
@@ -8,7 +8,7 @@ import BaseSelect from "@/components/Forms/Select/BaseSelect"
 import Button from "@/components/ui/Button"
 import { useCardDrawer } from "@/hooks/useCardDrawer"
 import { useProductFormOptions } from "@/hooks/useProductFormOptions"
-import { client } from "@/lib/api"
+import { api } from "@/lib/api"
 import {
   ActionsGroup,
   Badge,
@@ -51,38 +51,31 @@ export default function ProductCard({ product, editable = false }: Props) {
 
   const queryClient = useQueryClient()
 
-  const updateMutation = useMutation({
-    mutationFn: (vars: {
-      params: { id: string }
-      body: {
-        productName: string
-        categoryID: string
-        originID: string
-        territoryID: string
-        taxID: string
-      }
-    }) => client.api.products.update(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["products"] })
-      toast.success("Produit mis à jour")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la mise à jour")
-    },
-  })
+  const updateMutation = useMutation(
+    api.products.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.products.index.pathKey() })
+        toast.success("Produit mis à jour")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la mise à jour")
+      },
+    }),
+  )
 
-  const deleteMutation = useMutation({
-    mutationFn: (vars: { params: { id: string } }) => client.api.products.destroy(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["products"] })
-      toast.success("Produit supprimé")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la suppression")
-    },
-  })
+  const deleteMutation = useMutation(
+    api.products.destroy.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.products.index.pathKey() })
+        toast.success("Produit supprimé")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la suppression")
+      },
+    }),
+  )
 
   const isFormValid = useMemo(
     () => Boolean(productName.trim() && categoryID && originID && territoryID),

--- a/apps/dashboard/src/components/Dashboard/Territories/AddTerritory/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Territories/AddTerritory/index.tsx
@@ -3,14 +3,9 @@ import { useId, useState } from "react"
 import { toast } from "sonner"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import Modal from "@/components/Modal"
-import Button from "@/components/ui/Button"
-import { client } from "@/lib/api"
-import {
-  AddTerritoryBtn,
-  AddTerritoryContainer,
-  ErrorContainer,
-  TerritoryActions,
-} from "./AddTerritory.styled"
+import ModalCard from "@/components/Modal/ModalCard"
+import { api } from "@/lib/api"
+import { AddTerritoryBtn, ErrorContainer } from "./AddTerritory.styled"
 
 export default function AddTerritory() {
   const [show, setShow] = useState(false)
@@ -19,18 +14,18 @@ export default function AddTerritory() {
 
   const queryClient = useQueryClient()
 
-  const createMutation = useMutation({
-    mutationFn: (body: { territoryName: string; available: boolean }) =>
-      client.api.territories.store({ body }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["territories"] })
-      toast.success("Territoire créé avec succès")
-      handleClose()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la création")
-    },
-  })
+  const createMutation = useMutation(
+    api.territories.store.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.territories.index.pathKey() })
+        toast.success("Territoire créé avec succès")
+        handleClose()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la création")
+      },
+    }),
+  )
 
   const isFormValid = territoryName.trim() !== ""
 
@@ -43,10 +38,11 @@ export default function AddTerritory() {
     resetForm()
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = () => {
     if (!isFormValid) return
-    createMutation.mutate({ territoryName: territoryName.trim(), available: true })
+    createMutation.mutate({
+      body: { territoryName: territoryName.trim(), available: true },
+    })
   }
 
   const errors = createMutation.error ? ["Erreur lors de la création"] : []
@@ -57,10 +53,21 @@ export default function AddTerritory() {
         Ajouter un territoire
       </AddTerritoryBtn>
       <Modal show={show} setShow={setShow}>
-        <AddTerritoryContainer>
-          <h2>Ajouter un territoire</h2>
-          <hr />
-          <form onSubmit={handleSubmit} autoComplete="off">
+        <ModalCard
+          title="Ajouter un territoire"
+          onClose={handleClose}
+          submitLabel="Créer le territoire"
+          onSubmit={handleSubmit}
+          submitDisabled={!isFormValid || createMutation.isPending}
+          submitLoading={createMutation.isPending}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmit()
+            }}
+            autoComplete="off"
+          >
             <InputContainer>
               <label htmlFor={territoryNameID}>Nom du territoire *</label>
               <input
@@ -73,22 +80,15 @@ export default function AddTerritory() {
                 onChange={(e) => setTerritoryName(e.target.value)}
               />
             </InputContainer>
-            <TerritoryActions>
+            {errors.length > 0 && (
               <ErrorContainer>
-                {errors.length > 0 &&
-                  errors.map((error, index) => <span key={index}>{error}</span>)}
+                {errors.map((error, index) => (
+                  <span key={index}>{error}</span>
+                ))}
               </ErrorContainer>
-              <div style={{ display: "flex", gap: 8 }}>
-                <Button type="button" onClick={handleClose}>
-                  Annuler
-                </Button>
-                <Button type="submit" aria-disabled={!isFormValid || createMutation.isPending}>
-                  {createMutation.isPending ? "Création..." : "Créer le territoire"}
-                </Button>
-              </div>
-            </TerritoryActions>
+            )}
           </form>
-        </AddTerritoryContainer>
+        </ModalCard>
       </Modal>
     </>
   )

--- a/apps/dashboard/src/components/Dashboard/Territories/TerritoryCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Territories/TerritoryCard/index.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner"
 import { Drawer } from "vaul"
 import Button from "@/components/ui/Button"
 import { useCardDrawer } from "@/hooks/useCardDrawer"
-import { client } from "@/lib/api"
+import { api } from "@/lib/api"
 import {
   ActionsGroup,
   Card,
@@ -47,32 +47,31 @@ export default function TerritoryCard({ territory, editable = false }: Props) {
 
   const queryClient = useQueryClient()
 
-  const updateMutation = useMutation({
-    mutationFn: (vars: {
-      params: { id: string }
-      body: { territoryName: string; available: boolean }
-    }) => client.api.territories.update(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["territories"] })
-      toast.success("Territoire mis à jour")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la mise à jour")
-    },
-  })
+  const updateMutation = useMutation(
+    api.territories.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.territories.index.pathKey() })
+        toast.success("Territoire mis à jour")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la mise à jour")
+      },
+    }),
+  )
 
-  const deleteMutation = useMutation({
-    mutationFn: (vars: { params: { id: string } }) => client.api.territories.destroy(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["territories"] })
-      toast.success("Territoire supprimé")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la suppression")
-    },
-  })
+  const deleteMutation = useMutation(
+    api.territories.destroy.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.territories.index.pathKey() })
+        toast.success("Territoire supprimé")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la suppression")
+      },
+    }),
+  )
 
   const isFormValid = useMemo(() => Boolean(territoryName.trim()), [territoryName])
 

--- a/apps/dashboard/src/components/Dashboard/Transporters/AddTransporter/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Transporters/AddTransporter/index.tsx
@@ -3,14 +3,9 @@ import { useId, useState } from "react"
 import { toast } from "sonner"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import Modal from "@/components/Modal"
-import Button from "@/components/ui/Button"
-import { client } from "@/lib/api"
-import {
-  AddTransporterBtn,
-  AddTransporterContainer,
-  ErrorContainer,
-  TransporterActions,
-} from "./AddTransporter.styled"
+import ModalCard from "@/components/Modal/ModalCard"
+import { api } from "@/lib/api"
+import { AddTransporterBtn, ErrorContainer } from "./AddTransporter.styled"
 
 export default function AddTransporter() {
   const [show, setShow] = useState(false)
@@ -19,18 +14,18 @@ export default function AddTransporter() {
 
   const queryClient = useQueryClient()
 
-  const createMutation = useMutation({
-    mutationFn: (body: { transporterName: string; available: boolean }) =>
-      client.api.transporters.store({ body }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["transporters"] })
-      toast.success("Transporteur créé avec succès")
-      handleClose()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la création")
-    },
-  })
+  const createMutation = useMutation(
+    api.transporters.store.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.transporters.index.pathKey() })
+        toast.success("Transporteur créé avec succès")
+        handleClose()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la création")
+      },
+    }),
+  )
 
   const isFormValid = transporterName.trim() !== ""
 
@@ -43,10 +38,11 @@ export default function AddTransporter() {
     resetForm()
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = () => {
     if (!isFormValid) return
-    createMutation.mutate({ transporterName: transporterName.trim(), available: true })
+    createMutation.mutate({
+      body: { transporterName: transporterName.trim(), available: true },
+    })
   }
 
   const errors = createMutation.error ? ["Erreur lors de la création"] : []
@@ -57,10 +53,21 @@ export default function AddTransporter() {
         Ajouter un transporteur
       </AddTransporterBtn>
       <Modal show={show} setShow={setShow}>
-        <AddTransporterContainer>
-          <h2>Ajouter un transporteur</h2>
-          <hr />
-          <form onSubmit={handleSubmit} autoComplete="off">
+        <ModalCard
+          title="Ajouter un transporteur"
+          onClose={handleClose}
+          submitLabel="Créer le transporteur"
+          onSubmit={handleSubmit}
+          submitDisabled={!isFormValid || createMutation.isPending}
+          submitLoading={createMutation.isPending}
+        >
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSubmit()
+            }}
+            autoComplete="off"
+          >
             <InputContainer>
               <label htmlFor={transporterNameID}>Nom du transporteur *</label>
               <input
@@ -73,22 +80,15 @@ export default function AddTransporter() {
                 onChange={(e) => setTransporterName(e.target.value.toUpperCase())}
               />
             </InputContainer>
-            <TransporterActions>
+            {errors.length > 0 && (
               <ErrorContainer>
-                {errors.length > 0 &&
-                  errors.map((error, index) => <span key={index}>{error}</span>)}
+                {errors.map((error, index) => (
+                  <span key={index}>{error}</span>
+                ))}
               </ErrorContainer>
-              <div style={{ display: "flex", gap: 8 }}>
-                <Button type="button" onClick={handleClose}>
-                  Annuler
-                </Button>
-                <Button type="submit" aria-disabled={!isFormValid || createMutation.isPending}>
-                  {createMutation.isPending ? "Création..." : "Créer le transporteur"}
-                </Button>
-              </div>
-            </TransporterActions>
+            )}
           </form>
-        </AddTransporterContainer>
+        </ModalCard>
       </Modal>
     </>
   )

--- a/apps/dashboard/src/components/Dashboard/Transporters/TransporterCard/index.tsx
+++ b/apps/dashboard/src/components/Dashboard/Transporters/TransporterCard/index.tsx
@@ -6,7 +6,7 @@ import { toast } from "sonner"
 import { Drawer } from "vaul"
 import Button from "@/components/ui/Button"
 import { useCardDrawer } from "@/hooks/useCardDrawer"
-import { client } from "@/lib/api"
+import { api } from "@/lib/api"
 import {
   ActionsGroup,
   Card,
@@ -49,32 +49,31 @@ export default function TransporterCard({ transporter, editable = false }: Props
 
   const queryClient = useQueryClient()
 
-  const updateMutation = useMutation({
-    mutationFn: (vars: {
-      params: { id: string }
-      body: { transporterName: string; available: boolean }
-    }) => client.api.transporters.update(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["transporters"] })
-      toast.success("Transporteur mis à jour")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la mise à jour")
-    },
-  })
+  const updateMutation = useMutation(
+    api.transporters.update.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.transporters.index.pathKey() })
+        toast.success("Transporteur mis à jour")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la mise à jour")
+      },
+    }),
+  )
 
-  const deleteMutation = useMutation({
-    mutationFn: (vars: { params: { id: string } }) => client.api.transporters.destroy(vars),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["transporters"] })
-      toast.success("Transporteur supprimé")
-      drawer.closeDrawer()
-    },
-    onError: () => {
-      toast.error("Erreur lors de la suppression")
-    },
-  })
+  const deleteMutation = useMutation(
+    api.transporters.destroy.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: api.transporters.index.pathKey() })
+        toast.success("Transporteur supprimé")
+        drawer.closeDrawer()
+      },
+      onError: () => {
+        toast.error("Erreur lors de la suppression")
+      },
+    }),
+  )
 
   const isFormValid = useMemo(() => Boolean(transporterName.trim()), [transporterName])
 

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query"
 import { registry } from "@taxdom/api/registry"
 import { createTuyau } from "@tuyau/core/client"
+import { createTuyauReactQueryClient } from "@tuyau/react-query"
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,3 +19,10 @@ export const client = createTuyau({
   credentials: "include",
   headers: { Accept: "application/json" },
 })
+
+/**
+ * Type-safe TanStack Query client generated from Tuyau registry.
+ * Use this for all queries and mutations to get end-to-end type safety
+ * and automatic query key management.
+ */
+export const api = createTuyauReactQueryClient({ client })

--- a/apps/dashboard/src/lib/transporterRules.ts
+++ b/apps/dashboard/src/lib/transporterRules.ts
@@ -6,32 +6,12 @@ export async function saveTransporterRules(data: {
   edges: unknown[]
   rules: unknown[]
 }) {
-  return client.api.transporterRules.saveAll({
+  return client.post("/v1/admin/transporters/:transporterId/rules", {
     params: { transporterId: data.transporterID },
     body: {
-      nodes: data.nodes as {
-        nodeID?: string | null
-        nodeData?: unknown
-        nodeType: "start" | "condition" | "fee"
-        positionX: string | number
-        positionY: string | number
-      }[],
-      edges: data.edges as {
-        edgeID?: string | null
-        sourceHandle?: "default" | "no" | "yes" | null
-        edgeLabel?: string | null
-        sourceNodeID: string
-        targetNodeID: string
-      }[],
-      rules: data.rules as {
-        ruleID?: string | null
-        priority: string | number
-        fee: string
-        minAmount: string | number | null
-        maxAmount: string | number | null
-        isIndividual: string | number | boolean | null
-        originIsEU: string | number | boolean | null
-      }[],
+      nodes: data.nodes,
+      edges: data.edges,
+      rules: data.rules,
     },
-  })
+  } as any)
 }

--- a/apps/dashboard/src/routes/_dashboard-layout/categories.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/categories.tsx
@@ -2,14 +2,11 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import Categories from "@/components/Dashboard/Categories"
 import LoadingFallback from "@/components/Dashboard/shared/LoadingFallback"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/categories")({
   loader: async () => {
-    const categories = await queryClient.ensureQueryData({
-      queryKey: ["categories"],
-      queryFn: async () => client.api.categories.index({}),
-    })
+    const categories = await queryClient.ensureQueryData(api.categories.index.queryOptions())
     return { categories }
   },
   component: CategoriesPage,

--- a/apps/dashboard/src/routes/_dashboard-layout/index.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import Overview from "@/components/Dashboard/Overview"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 interface DashboardStats {
   products_count: number
@@ -28,61 +28,65 @@ interface TopTerritory {
   territoryID: string
   territoryName: string
   productsCount: number
-  available: boolean
 }
 
 export const Route = createFileRoute("/_dashboard-layout/")({
   loader: async () => {
-    const productsCount = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-stats-products"],
-      queryFn: async () => client.api.products.count({}),
-      staleTime: 1000 * 60 * 60,
-    })
-    const categoriesCount = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-stats-categories"],
-      queryFn: async () => client.api.categories.count({}),
-      staleTime: 1000 * 60 * 60,
-    })
-    const originsCount = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-stats-origins"],
-      queryFn: async () => client.api.origins.count({}),
-      staleTime: 1000 * 60 * 60,
-    })
-    const territoriesCount = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-stats-territories"],
-      queryFn: async () => client.api.territories.count({}),
-      staleTime: 1000 * 60 * 60,
-    })
-    const recentProducts = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-recent-products"],
-      queryFn: async () => {
-        const data = await client.api.products.recent({})
-        return (
-          Array.isArray(data) ? data : ((data as Record<string, unknown>).recent_products ?? [])
-        ) as RecentProduct[]
-      },
-      staleTime: 1000 * 60 * 5,
-    })
-    const topOrigins = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-top-origins"],
-      queryFn: async () => {
-        const data = await client.api.origins.top({})
-        return (
-          Array.isArray(data) ? data : ((data as Record<string, unknown>).top_origins ?? [])
-        ) as TopOrigin[]
-      },
-      staleTime: 1000 * 60 * 60,
-    })
-    const topTerritories = await queryClient.ensureQueryData({
-      queryKey: ["dashboard-top-territories"],
-      queryFn: async () => {
-        const data = await client.api.territories.top({})
-        return (
-          Array.isArray(data) ? data : ((data as Record<string, unknown>).top_territories ?? [])
-        ) as TopTerritory[]
-      },
-      staleTime: 1000 * 60 * 60,
-    })
+    const productsCount = await queryClient.ensureQueryData(
+      api.products.count.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+    const categoriesCount = await queryClient.ensureQueryData(
+      api.categories.count.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+    const originsCount = await queryClient.ensureQueryData(
+      api.origins.count.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+    const territoriesCount = await queryClient.ensureQueryData(
+      api.territories.count.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+
+    const recentProductsRaw = await queryClient.ensureQueryData(
+      api.products.recent.queryOptions({}, { staleTime: 1000 * 60 * 5 }),
+    )
+    const recentProductsArray = Array.isArray(recentProductsRaw)
+      ? recentProductsRaw
+      : (((recentProductsRaw as Record<string, unknown>).recent_products ?? []) as Array<{
+          productID: string
+          productName: string
+          categoryName?: string
+          originName?: string
+          createdAt?: string | Date | null
+        }>)
+    const recentProducts: RecentProduct[] = recentProductsArray.map((p) => ({
+      productID: p.productID,
+      productName: p.productName,
+      category: { categoryName: p.categoryName ?? "" },
+      origin: { originName: p.originName ?? "" },
+      createdAt:
+        typeof p.createdAt === "string"
+          ? p.createdAt
+          : p.createdAt instanceof Date
+            ? p.createdAt.toISOString()
+            : "",
+    }))
+
+    const topOriginsRaw = await queryClient.ensureQueryData(
+      api.origins.top.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+    const topOrigins = (
+      Array.isArray(topOriginsRaw)
+        ? topOriginsRaw
+        : ((topOriginsRaw as Record<string, unknown>).top_origins ?? [])
+    ) as TopOrigin[]
+
+    const topTerritoriesRaw = await queryClient.ensureQueryData(
+      api.territories.top.queryOptions({}, { staleTime: 1000 * 60 * 60 }),
+    )
+    const topTerritories = (
+      Array.isArray(topTerritoriesRaw)
+        ? topTerritoriesRaw
+        : ((topTerritoriesRaw as Record<string, unknown>).top_territories ?? [])
+    ) as TopTerritory[]
 
     return {
       stats: {
@@ -91,9 +95,9 @@ export const Route = createFileRoute("/_dashboard-layout/")({
         origins_count: (originsCount as Record<string, number>).origins_count ?? 0,
         territories_count: (territoriesCount as Record<string, number>).territories_count ?? 0,
       } as DashboardStats,
-      recentProducts: recentProducts as RecentProduct[],
-      topOrigins: topOrigins as TopOrigin[],
-      topTerritories: topTerritories as TopTerritory[],
+      recentProducts,
+      topOrigins,
+      topTerritories,
     }
   },
   component: OverviewPage,

--- a/apps/dashboard/src/routes/_dashboard-layout/origins.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/origins.tsx
@@ -2,14 +2,11 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import Origins from "@/components/Dashboard/Origins"
 import LoadingFallback from "@/components/Dashboard/shared/LoadingFallback"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/origins")({
   loader: async () => {
-    const origins = await queryClient.ensureQueryData({
-      queryKey: ["origins"],
-      queryFn: async () => client.api.origins.index({}),
-    })
+    const origins = await queryClient.ensureQueryData(api.origins.index.queryOptions())
     return { origins }
   },
   component: OriginsPage,

--- a/apps/dashboard/src/routes/_dashboard-layout/products.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/products.tsx
@@ -3,15 +3,12 @@ import { Suspense } from "react"
 import Products from "@/components/Dashboard/Products"
 import LoadingFallback from "@/components/Dashboard/shared/LoadingFallback"
 import { ErrorComponent } from "@/components/ErrorComponent"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/products")({
   loader: async () => {
-    const products = (await queryClient.ensureQueryData({
-      queryKey: ["products"],
-      queryFn: async () => client.api.products.index({}),
-    })) as import("@taxdom/types").Product[]
-    return { products }
+    const result = await queryClient.ensureQueryData(api.products.index.queryOptions())
+    return { products: (result as any)?.data ?? [] }
   },
   onError: ({ error }) => {
     console.error("Products route loader failed:", error)

--- a/apps/dashboard/src/routes/_dashboard-layout/territories.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/territories.tsx
@@ -2,14 +2,11 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import LoadingFallback from "@/components/Dashboard/shared/LoadingFallback"
 import Territories from "@/components/Dashboard/Territories"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/territories")({
   loader: async () => {
-    const territories = await queryClient.ensureQueryData({
-      queryKey: ["territories"],
-      queryFn: async () => client.api.territories.index({}),
-    })
+    const territories = await queryClient.ensureQueryData(api.territories.index.queryOptions())
     return { territories }
   },
   component: TerritoriesPage,

--- a/apps/dashboard/src/routes/_dashboard-layout/transporters.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/transporters.tsx
@@ -1,13 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router"
 import Transporters from "@/components/Dashboard/Transporters"
-import { client, queryClient } from "@/lib/api"
+import { api, queryClient } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/transporters")({
   loader: async () => {
-    const transporters = await queryClient.ensureQueryData({
-      queryKey: ["transporters"],
-      queryFn: async () => client.api.transporters.index({}),
-    })
+    const transporters = await queryClient.ensureQueryData(api.transporters.index.queryOptions())
     return { transporters }
   },
   component: TransportersPage,

--- a/apps/dashboard/src/routes/_dashboard-layout/transporters/editor.$id.tsx
+++ b/apps/dashboard/src/routes/_dashboard-layout/transporters/editor.$id.tsx
@@ -3,7 +3,7 @@ import type { TransporterFlowEdge, TransporterFlowNode } from "@taxdom/types"
 import { Suspense } from "react"
 import LoadingFallback from "@/components/Dashboard/shared/LoadingFallback"
 import RulesFlowEditor from "@/components/Dashboard/Transporters/RulesFlow/RulesFlowEditor"
-import { client } from "@/lib/api"
+import { api, client } from "@/lib/api"
 
 export const Route = createFileRoute("/_dashboard-layout/transporters/editor/$id")({
   loader: async ({ context, params }) => {
@@ -11,16 +11,13 @@ export const Route = createFileRoute("/_dashboard-layout/transporters/editor/$id
 
     const [transporter, flowData] = await Promise.all([
       context.queryClient
-        .ensureQueryData({
-          queryKey: ["transporter", id],
-          queryFn: async () => client.api.transporters.show({ params: { id } }),
-        })
+        .ensureQueryData(api.transporters.show.queryOptions({ params: { id } }))
         .catch(() => null) as Promise<Record<string, string> | null>,
       context.queryClient.ensureQueryData<{
         nodes: TransporterFlowNode[]
         edges: TransporterFlowEdge[]
       }>({
-        queryKey: ["transporter-flow", id],
+        queryKey: api.transporterRules.show.queryKey({ params: { transporterId: id } }),
         queryFn: async () => {
           try {
             const result = (await client.api.transporterRules.show({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-virtual": "3.13.24",
     "@taxdom/api": "workspace:*",
     "@tuyau/core": "1.2.2",
+    "@tuyau/react-query": "^1.1.0",
     "@wrksz/themes": "^0.8.3",
     "motion": "12.38.0",
     "next": "16.2.4",

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,4 +1,5 @@
 import { createTuyau } from "@tuyau/core/client"
+import { createTuyauReactQueryClient } from "@tuyau/react-query"
 import { registry } from "@taxdom/api/registry"
 
 const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3334"
@@ -8,3 +9,10 @@ export const apiClient = createTuyau({
   registry,
   headers: { Accept: "application/json" },
 })
+
+/**
+ * Type-safe TanStack Query client generated from Tuyau registry.
+ * Use this for all queries and mutations to get end-to-end type safety
+ * and automatic query key management.
+ */
+export const api = createTuyauReactQueryClient({ client: apiClient })

--- a/apps/web/src/lib/categories.ts
+++ b/apps/web/src/lib/categories.ts
@@ -1,15 +1,14 @@
 import type { Category } from "@taxdom/types"
-import { apiClient } from "./api-client"
+import { api } from "./api-client"
 
 /**
- * Fetch all available categories from the server
+ * Type-safe query options for fetching categories via Tuyau + TanStack Query.
+ * The query key is automatically managed by Tuyau.
  */
-export async function fetchCategories(): Promise<Category[]> {
-  try {
-    const categories = await apiClient.api.categories.index({})
-    return categories ?? []
-  } catch (error) {
-    console.error("Error fetching categories:", error)
-    return []
-  }
-}
+export const categoryQueryOptions = api.categories.index.queryOptions(
+  {},
+  {
+    staleTime: 60 * 60 * 1000, // 1 hour for reference data
+    select: (data): Category[] => data ?? [],
+  },
+)

--- a/apps/web/src/lib/fetchTemplate.ts
+++ b/apps/web/src/lib/fetchTemplate.ts
@@ -1,12 +1,10 @@
 import type { ParcelSimulatorTemplateType } from "@/components/services/ParcelSimulator/types"
-import { queryOptions } from "@tanstack/react-query"
-import { apiClient } from "./api-client"
+import { api } from "./api-client"
 
-export const fetchTemplates = queryOptions({
-  queryKey: ["templates"],
-  staleTime: 24 * 60 * 60 * 1000, // 24 hours
-  queryFn: async () => {
-    const res = await apiClient.api.getTemplates({})
-    return res as ParcelSimulatorTemplateType
+export const fetchTemplates = api.getTemplates.queryOptions(
+  {},
+  {
+    staleTime: 24 * 60 * 60 * 1000, // 24 hours
+    select: (data) => data as ParcelSimulatorTemplateType,
   },
-})
+)

--- a/apps/web/src/lib/origins.ts
+++ b/apps/web/src/lib/origins.ts
@@ -1,25 +1,18 @@
 import type { SelectOption } from "@taxdom/types"
-import { queryOptions } from "@tanstack/react-query"
-import { apiClient } from "./api-client"
-
-export type OriginResponse = {
-  name: string
-  isEU: boolean
-}
+import { api } from "./api-client"
 
 /**
- * Fetch all available origins from the public API
+ * Type-safe query options for fetching origins via Tuyau + TanStack Query.
+ * The query key is automatically managed by Tuyau.
  */
-export async function fetchOrigins(): Promise<SelectOption[]> {
-  const origins = await apiClient.api.origins.list({})
-  return origins.map((o) => ({
-    name: o.name,
-    available: true,
-  }))
-}
-
-export const originQueryOptions = queryOptions({
-  queryKey: ["origins"],
-  queryFn: fetchOrigins,
-  staleTime: 60 * 60 * 1000, // 1 hour for reference data
-})
+export const originQueryOptions = api.origins.list.queryOptions(
+  {},
+  {
+    staleTime: 60 * 60 * 1000, // 1 hour for reference data
+    select: (data): SelectOption[] =>
+      data.map((o) => ({
+        name: o.name,
+        available: true,
+      })),
+  },
+)

--- a/apps/web/src/lib/territories.ts
+++ b/apps/web/src/lib/territories.ts
@@ -1,22 +1,14 @@
 import type { SelectOption } from "@taxdom/types"
-import { queryOptions } from "@tanstack/react-query"
-import { apiClient } from "./api-client"
+import { api } from "./api-client"
 
 /**
- * Fetch all available territories from the server
+ * Type-safe query options for fetching territories via Tuyau + TanStack Query.
+ * The query key is automatically managed by Tuyau.
  */
-export async function fetchTerritories(): Promise<SelectOption[]> {
-  try {
-    const territories = await apiClient.api.territories.list({})
-    return territories.map((territory) => ({ name: territory.name }))
-  } catch (error) {
-    console.error("Error fetching territories:", error)
-    return []
-  }
-}
-
-export const territoryQueryOptions = queryOptions({
-  queryKey: ["territories"],
-  queryFn: fetchTerritories,
-  staleTime: 60 * 60 * 1000,
-})
+export const territoryQueryOptions = api.territories.list.queryOptions(
+  {},
+  {
+    staleTime: 60 * 60 * 1000,
+    select: (data): SelectOption[] => data.map((territory) => ({ name: territory.name })),
+  },
+)

--- a/apps/web/src/lib/transporters.ts
+++ b/apps/web/src/lib/transporters.ts
@@ -1,22 +1,14 @@
 import type { SelectOption } from "@taxdom/types"
-import { queryOptions } from "@tanstack/react-query"
-import { apiClient } from "./api-client"
+import { api } from "./api-client"
 
 /**
- * Fetch all available transporters from the server
+ * Type-safe query options for fetching transporters via Tuyau + TanStack Query.
+ * The query key is automatically managed by Tuyau.
  */
-export async function fetchTransporters(): Promise<SelectOption[]> {
-  try {
-    const transporters = await apiClient.api.transporters.list({})
-    return transporters.map((transporter) => ({ name: transporter.name }))
-  } catch (error) {
-    console.error("Error fetching transporters:", error)
-    return []
-  }
-}
-
-export const transporterQueryOptions = queryOptions({
-  queryKey: ["transporters"],
-  queryFn: fetchTransporters,
-  staleTime: 60 * 60 * 1000,
-})
+export const transporterQueryOptions = api.transporters.list.queryOptions(
+  {},
+  {
+    staleTime: 60 * 60 * 1000,
+    select: (data): SelectOption[] => data.map((transporter) => ({ name: transporter.name })),
+  },
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,15 +41,15 @@ importers:
         version: 10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
       '@adonisjs/session':
         specifier: 8.1.0
-        version: 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
+        version: 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))
       '@adonisjs/shield':
         specifier: 9.0.0
-        version: 9.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/session@8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))))
+        version: 9.0.0(5fcb12be6f18f65dc98b31a11e0e83a8)
       '@better-auth/drizzle-adapter':
         specifier: 1.6.9
         version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(gel@2.0.1)(kysely@0.28.14)(pg@8.20.0))
       '@tuyau/core':
-        specifier: ^1.2.2
+        specifier: 1.2.2
         version: 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
       '@vinejs/vine':
         specifier: 4.4.0
@@ -79,6 +79,18 @@ importers:
       '@adonisjs/tsconfig':
         specifier: 2.0.0
         version: 2.0.0
+      '@japa/api-client':
+        specifier: ^3.2.1
+        version: 3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)
+      '@japa/assert':
+        specifier: ^4.2.0
+        version: 4.2.0(@japa/runner@5.3.0)
+      '@japa/plugin-adonisjs':
+        specifier: ^5.2.0
+        version: 5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0)
+      '@japa/runner':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@poppinss/ts-exec':
         specifier: 1.4.4
         version: 1.4.4
@@ -166,10 +178,13 @@ importers:
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@taxdom/api':
         specifier: workspace:*
-        version: file:apps/api(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(drizzle-kit@0.31.10)(gel@2.0.1)(kysely@0.28.14)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pino-pretty@13.1.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(youch@4.1.1)
+        version: file:apps/api(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(drizzle-kit@0.31.10)(gel@2.0.1)(kysely@0.28.14)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pino-pretty@13.1.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(youch@4.1.1)
       '@tuyau/core':
         specifier: 1.2.2
         version: 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
+      '@tuyau/react-query':
+        specifier: ^1.1.0
+        version: 1.1.0(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@tuyau/core@1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
       '@xyflow/react':
         specifier: 12.10.2
         version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -250,8 +265,11 @@ importers:
         specifier: workspace:*
         version: link:../api
       '@tuyau/core':
-        specifier: ^1.2.2
+        specifier: 1.2.2
         version: 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
+      '@tuyau/react-query':
+        specifier: ^1.1.0
+        version: 1.1.0(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@tuyau/core@1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
       '@wrksz/themes':
         specifier: ^0.8.3
         version: 0.8.3(next@16.2.4(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
@@ -1548,6 +1566,66 @@ packages:
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
 
+  '@japa/api-client@3.2.1':
+    resolution: {integrity: sha512-dICbeEkgGRpjkm3CviOpvPfYMBZddaoW2w20pgNMm3CfvD2bixWOFn6FBRZRq5L+fHYe/O/xfSNGMCQBFy7Zlw==}
+    engines: {node: '>=18.16.0'}
+    peerDependencies:
+      '@japa/assert': ^2.0.0 || ^3.0.0 || ^4.0.0
+      '@japa/openapi-assertions': ^0.1.1
+      '@japa/runner': ^3.1.2 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@japa/assert':
+        optional: true
+      '@japa/openapi-assertions':
+        optional: true
+
+  '@japa/assert@4.2.0':
+    resolution: {integrity: sha512-Krgrcee01BN1StlVwK5JQP6LL5t3DE3uFNbfFoDTfW7kQuHB0xh6yfaV0hrgcoiEjsqmm2OOsVWeju9aXK4vIA==}
+    engines: {node: '>=18.16.0'}
+    peerDependencies:
+      '@japa/runner': ^3.1.2 || ^4.0.0 || ^5.0.0
+
+  '@japa/core@10.4.0':
+    resolution: {integrity: sha512-1zvKL29i7r/4jqTNBsw91hk1tp6wbqFXvyV2p+Og4axDRhIXjSAfauRvBL9QuB80bOa+pDIMQ5kCTaCplSm0Eg==}
+    engines: {node: '>=24.0.0'}
+
+  '@japa/errors-printer@4.1.4':
+    resolution: {integrity: sha512-ogPT87QLaugKyPVcq+ZypcetVeJpXZN7RfVRlRDIrSHsHBw6ILCtNXghVxD9POjqxtUM7RON3sUkgZzLnVQA5g==}
+    engines: {node: '>=18.16.0'}
+
+  '@japa/plugin-adonisjs@5.2.0':
+    resolution: {integrity: sha512-Knk3X/UeZiEvkXmTj9+dAIOdJHMqRUJFsUMw9y8at+AR1VbPJR9T+aU5SaOn6OtejEFnUMILwJYC3ohg23+vhw==}
+    engines: {node: '>=18.16.0'}
+    peerDependencies:
+      '@adonisjs/core': ^7.0.0-next.21 || ^7.0.0
+      '@japa/api-client': ^3.1.0
+      '@japa/browser-client': ^2.2.0
+      '@japa/runner': ^4.0.0 || ^5.0.0
+      playwright: ^1.57.0
+    peerDependenciesMeta:
+      '@japa/api-client':
+        optional: true
+      '@japa/browser-client':
+        optional: true
+      playwright:
+        optional: true
+
+  '@japa/runner@5.3.0':
+    resolution: {integrity: sha512-WCnTd1q2EpbKKa96NzL16kVxJXVLRj1VqbswNAn17hYSuMlNKKhPGNbAosB32QZVFcoe9fv4Ebh1HtjyAT/viw==}
+    engines: {node: '>=18.16.0'}
+
+  '@jest/diff-sequences@30.3.0':
+    resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1709,6 +1787,10 @@ packages:
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
@@ -1799,6 +1881,9 @@ packages:
 
   '@pandacss/types@1.10.0':
     resolution: {integrity: sha512-8R8s0QevHtT6Le8HH5hN1DJ1qH9EYeUGtI2MhvXIChV3xjd2EZqhKpNTK7w2iw30z8mJhvCj0dWIUopn0sN2XQ==}
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@petamoriken/float16@3.9.2':
     resolution: {integrity: sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==}
@@ -2311,6 +2396,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -2632,6 +2720,20 @@ packages:
       '@adonisjs/core':
         optional: true
 
+  '@tuyau/query-core@1.1.0':
+    resolution: {integrity: sha512-5g7t0QBdB5jETSzJvPOF3Mnjzh3QbuM3Oo2W/7SbUBqAhS+alRAxvBPC4HkAJN5aTlfGnpTEpQlETkI61y77bA==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@tanstack/query-core': ^5.74.7
+      '@tuyau/core': ^1.0.0-beta.9
+
+  '@tuyau/react-query@1.1.0':
+    resolution: {integrity: sha512-lnfv7xPpYgSUlw+xezqWLxhjDW1QEH/Mek98j8brLLnei0FAUcAFASwnh7LRk5/cKfjUapVurJetLrFr9mpxHg==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@tanstack/react-query': ^5.74.7
+      '@tuyau/core': ^1.0.0-beta.9
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -2646,6 +2748,12 @@ packages:
 
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
@@ -2668,6 +2776,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2688,6 +2799,9 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -2723,6 +2837,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2863,6 +2980,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2896,6 +3017,13 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -2908,6 +3036,12 @@ packages:
     resolution: {integrity: sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -3081,6 +3215,14 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -3166,6 +3308,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -3180,6 +3326,12 @@ packages:
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
+
+  common-path-prefix@3.0.0:
+    resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -3198,6 +3350,9 @@ packages:
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
+  cookie-es@2.0.1:
+    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
+
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
@@ -3212,6 +3367,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -3356,6 +3514,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -3391,6 +3553,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
@@ -3580,6 +3745,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -3739,6 +3908,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-cache-directory@6.0.0:
+    resolution: {integrity: sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA==}
+    engines: {node: '>=20'}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -3754,9 +3927,17 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3845,6 +4026,9 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  getopts@2.3.0:
+    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
@@ -3874,8 +4058,16 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -4091,6 +4283,10 @@ packages:
 
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+
+  jest-diff@30.3.0:
+    resolution: {integrity: sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -4443,6 +4639,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
   microdiff@1.5.0:
     resolution: {integrity: sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==}
 
@@ -4555,13 +4755,26 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -4925,6 +5138,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  pkg-dir@8.0.0:
+    resolution: {integrity: sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==}
+    engines: {node: '>=18'}
+
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
@@ -5021,6 +5238,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@30.3.0:
+    resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
@@ -5097,6 +5318,9 @@ packages:
     resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -5253,6 +5477,10 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -5341,6 +5569,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -5558,9 +5789,17 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -5593,6 +5832,9 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  timekeeper@2.3.1:
+    resolution: {integrity: sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -6354,7 +6596,7 @@ snapshots:
       '@poppinss/colors': 4.1.6
       string-width: 8.2.0
 
-  '@adonisjs/session@8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))':
+  '@adonisjs/session@8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))':
     dependencies:
       '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)
       '@poppinss/macroable': 1.1.2
@@ -6362,14 +6604,18 @@ snapshots:
     optionalDependencies:
       '@adonisjs/assembler': 8.4.0(typescript@6.0.3)
       '@adonisjs/redis': 10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
+      '@japa/api-client': 3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)
+      '@japa/plugin-adonisjs': 5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0)
 
-  '@adonisjs/shield@9.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/session@8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))))':
+  '@adonisjs/shield@9.0.0(5fcb12be6f18f65dc98b31a11e0e83a8)':
     dependencies:
       '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)
-      '@adonisjs/session': 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
+      '@adonisjs/session': 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))
       csrf: 3.1.0
     optionalDependencies:
       '@adonisjs/assembler': 8.4.0(typescript@6.0.3)
+      '@japa/api-client': 3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)
+      '@japa/plugin-adonisjs': 5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0)
 
   '@adonisjs/tsconfig@2.0.0': {}
 
@@ -7148,6 +7394,74 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)':
+    dependencies:
+      '@japa/runner': 5.3.0
+      '@poppinss/hooks': 7.3.0
+      '@poppinss/macroable': 1.1.2
+      '@poppinss/qs': 6.15.0
+      '@types/superagent': 8.1.9
+      cookie-es: 2.0.1
+      set-cookie-parser: 2.7.2
+      superagent: 10.3.0
+    optionalDependencies:
+      '@japa/assert': 4.2.0(@japa/runner@5.3.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@japa/assert@4.2.0(@japa/runner@5.3.0)':
+    dependencies:
+      '@japa/runner': 5.3.0
+      '@poppinss/macroable': 1.1.2
+      '@types/chai': 5.2.3
+      assertion-error: 2.0.1
+      chai: 6.2.2
+
+  '@japa/core@10.4.0':
+    dependencies:
+      '@poppinss/hooks': 7.3.0
+      '@poppinss/macroable': 1.1.2
+      '@poppinss/string': 1.7.1
+      async-retry: 1.3.3
+      emittery: 1.2.1
+      string-width: 8.2.0
+
+  '@japa/errors-printer@4.1.4':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      jest-diff: 30.3.0
+      supports-color: 10.2.2
+      youch: 4.1.1
+
+  '@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0)':
+    dependencies:
+      '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)
+      '@japa/runner': 5.3.0
+    optionalDependencies:
+      '@japa/api-client': 3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)
+
+  '@japa/runner@5.3.0':
+    dependencies:
+      '@japa/core': 10.4.0
+      '@japa/errors-printer': 4.1.4
+      '@poppinss/colors': 4.1.6
+      '@poppinss/hooks': 7.3.0
+      '@poppinss/string': 1.7.1
+      '@poppinss/utils': 7.0.1
+      error-stack-parser-es: 1.0.5
+      find-cache-directory: 6.0.0
+      getopts: 2.3.0
+      supports-color: 10.2.2
+      timekeeper: 2.3.1
+
+  '@jest/diff-sequences@30.3.0': {}
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.49
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7328,6 +7642,8 @@ snapshots:
     optional: true
 
   '@noble/ciphers@2.1.1': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -7558,6 +7874,10 @@ snapshots:
       ts-pattern: 5.9.0
 
   '@pandacss/types@1.10.0': {}
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@petamoriken/float16@3.9.2':
     optional: true
@@ -7956,6 +8276,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sinclair/typebox@0.34.49': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/is@8.0.0': {}
@@ -8183,14 +8505,14 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 
-  '@taxdom/api@file:apps/api(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(drizzle-kit@0.31.10)(gel@2.0.1)(kysely@0.28.14)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pino-pretty@13.1.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(youch@4.1.1)':
+  '@taxdom/api@file:apps/api(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(drizzle-kit@0.31.10)(gel@2.0.1)(kysely@0.28.14)(mongodb@7.1.0)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pino-pretty@13.1.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(youch@4.1.1)':
     dependencies:
       '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)
       '@adonisjs/cors': 3.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
       '@adonisjs/limiter': 3.0.1(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
       '@adonisjs/redis': 10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
-      '@adonisjs/session': 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
-      '@adonisjs/shield': 9.0.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/session@8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))))
+      '@adonisjs/session': 8.1.0(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@adonisjs/redis@10.0.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0))(@japa/runner@5.3.0))
+      '@adonisjs/shield': 9.0.0(5fcb12be6f18f65dc98b31a11e0e83a8)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.14)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(better-sqlite3@12.4.1)(gel@2.0.1)(kysely@0.28.14)(pg@8.20.0))
       '@tuyau/core': 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
       '@vinejs/vine': 4.4.0
@@ -8307,6 +8629,19 @@ snapshots:
       '@adonisjs/assembler': 8.4.0(typescript@6.0.3)
       '@adonisjs/core': 7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)
 
+  '@tuyau/query-core@1.1.0(@tanstack/query-core@5.100.5)(@tuyau/core@1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))':
+    dependencies:
+      '@tanstack/query-core': 5.100.5
+      '@tuyau/core': 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
+
+  '@tuyau/react-query@1.1.0(@tanstack/query-core@5.100.5)(@tanstack/react-query@5.100.5(react@19.2.5))(@tuyau/core@1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))':
+    dependencies:
+      '@tanstack/react-query': 5.100.5(react@19.2.5)
+      '@tuyau/core': 1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1))
+      '@tuyau/query-core': 1.1.0(@tanstack/query-core@5.100.5)(@tuyau/core@1.2.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@adonisjs/core@7.3.2(@adonisjs/assembler@8.4.0(typescript@6.0.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(youch@4.1.1)))
+    transitivePeerDependencies:
+      - '@tanstack/query-core'
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -8333,6 +8668,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/cookiejar@2.1.5': {}
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
@@ -8358,6 +8700,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -8377,6 +8721,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
+
+  '@types/methods@1.1.4': {}
 
   '@types/ms@2.1.0': {}
 
@@ -8415,6 +8761,13 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 25.6.0
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 25.6.0
+      form-data: 4.0.5
 
   '@types/unist@2.0.11': {}
 
@@ -8578,6 +8931,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   ansi-styles@6.2.3: {}
@@ -8600,6 +8955,10 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -8697,6 +9056,12 @@ snapshots:
       - typescript
       - uploadthing
       - yaml
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -8853,6 +9218,13 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -8930,6 +9302,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -8937,6 +9313,10 @@ snapshots:
   commander@14.0.3: {}
 
   common-ancestor-path@2.0.0: {}
+
+  common-path-prefix@3.0.0: {}
+
+  component-emitter@1.3.1: {}
 
   confbox@0.2.2: {}
 
@@ -8948,6 +9328,8 @@ snapshots:
 
   cookie-es@1.2.3: {}
 
+  cookie-es@2.0.1: {}
+
   cookie-es@3.1.1: {}
 
   cookie-signature@1.2.2: {}
@@ -8955,6 +9337,8 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cookiejar@2.1.4: {}
 
   cors@2.8.5:
     dependencies:
@@ -9085,6 +9469,8 @@ snapshots:
 
   defu@6.1.7: {}
 
+  delayed-stream@1.0.0: {}
+
   denque@2.1.0: {}
 
   depd@2.0.0: {}
@@ -9107,6 +9493,11 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   diff@8.0.3: {}
 
@@ -9198,6 +9589,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -9478,6 +9876,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-cache-directory@6.0.0:
+    dependencies:
+      common-path-prefix: 3.0.0
+      pkg-dir: 8.0.0
+
   find-up-simple@1.0.1: {}
 
   flattie@1.1.1: {}
@@ -9490,10 +9893,24 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
     optional: true
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -9581,6 +9998,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  getopts@2.3.0: {}
+
   github-from-package@0.0.0:
     optional: true
 
@@ -9614,7 +10033,13 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -9888,6 +10313,13 @@ snapshots:
     optional: true
 
   javascript-stringify@2.1.0: {}
+
+  jest-diff@30.3.0:
+    dependencies:
+      '@jest/diff-sequences': 30.3.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.3.0
 
   jiti@2.6.1: {}
 
@@ -10296,6 +10728,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  methods@1.1.2: {}
+
   microdiff@1.5.0: {}
 
   micromark-core-commonmark@2.0.3:
@@ -10567,11 +11001,19 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@2.6.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -10912,6 +11354,10 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  pkg-dir@8.0.0:
+    dependencies:
+      find-up-simple: 1.0.1
+
   pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
@@ -11007,6 +11453,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@30.3.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-hrtime@1.0.3: {}
 
   pretty-ms@9.2.0:
@@ -11076,6 +11528,8 @@ snapshots:
   react-error-boundary@6.1.1(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  react-is@18.3.1: {}
 
   react-refresh@0.18.0: {}
 
@@ -11302,6 +11756,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -11429,6 +11885,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 
@@ -11680,7 +12138,25 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.5
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.1
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@10.2.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   svgo@4.0.1:
     dependencies:
@@ -11726,6 +12202,8 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  timekeeper@2.3.1: {}
 
   tiny-inflate@1.0.3: {}
 


### PR DESCRIPTION
Integrates `@tuyau/react-query` into the TaxDOM monorepo to provide end-to-end type safety between the AdonisJS API and its TanStack Query consumers (`apps/dashboard` and `apps/web`).
### Problem
Previously, the dashboard and web applications consumed the AdonisJS API using:
- **Raw `client` calls** with manual `queryKey` strings and no automatic invalidation mapping
- **Manually written `queryOptions` and `useMutation` hooks** decoupled from the API schema
- **Direct `client.api.*` calls** without TanStack Query integration, forcing boilerplate for cache invalidation and key management
If a route signature changed, a validator was renamed, or a response shape evolved on the API side, consumers would only detect the error at runtime. TypeScript offered no protection for query keys, mutation payloads, or invalidation paths.
### Solution
By wiring `@tuyau/react-query` into the existing `createTuyau()` clients, we now generate a type-safe TanStack Query layer directly from the Tuyau registry. This provides:
- **Automatic query key management**: `api.products.index.queryOptions()` derives the key from the route name — no more hardcoded strings
- **Type-safe mutations**: `api.products.update.mutationOptions()` infers `body`, `params`, and `response` types from VineJS validators
- **Automatic invalidation paths**: `api.products.index.pathKey()` gives the exact query key prefix to invalidate after a mutation
- **Monorepo-ready**: registry exported via `@taxdom/api`, consumed by both `dashboard` and `web` apps