### PR TITLE
feat: use UUID primary keys (`uuidv7()`)

### DIFF
--- a/apps/api/database/schema.ts
+++ b/apps/api/database/schema.ts
@@ -1,4 +1,4 @@
-import { relations } from "drizzle-orm"
+import { relations, sql } from "drizzle-orm"
 import {
   boolean,
   decimal,
@@ -6,43 +6,44 @@ import {
   pgTable,
   primaryKey,
   timestamp,
+  uuid,
   varchar,
 } from "drizzle-orm/pg-core"
 
 export const categories = pgTable(
   "categories",
   {
-    categoryID: varchar("category_id").notNull().primaryKey(),
-    categoryName: varchar("category_name").notNull(),
-    taxID: varchar("tax_id")
-      .references(() => taxes.taxID)
-      .notNull(),
+    categoryID: uuid("category_id").primaryKey().default(sql`uuidv7()`),
+    categoryName: varchar("category_name").notNull().unique(),
+    taxID: uuid("tax_id")
+      .notNull()
+      .references(() => taxes.taxID, { onDelete: "restrict", onUpdate: "cascade" }),
   },
   (table) => [index("categories_taxID_idx").on(table.taxID)],
 )
 
 export const origins = pgTable("origins", {
-  originID: varchar("origin_id").notNull().primaryKey(),
+  originID: uuid("origin_id").primaryKey().default(sql`uuidv7()`),
   originName: varchar("origin_name").notNull().unique(),
   available: boolean("available").notNull().default(true),
   isEU: boolean("is_eu").notNull().default(false),
 })
 
 export const taxes = pgTable("taxes", {
-  taxID: varchar("tax_id").notNull().primaryKey(),
+  taxID: uuid("tax_id").primaryKey().default(sql`uuidv7()`),
   tva: decimal("tva", { precision: 10, scale: 2 }).notNull(),
   om: decimal("om", { precision: 10, scale: 2 }).notNull(),
   omr: decimal("omr", { precision: 10, scale: 2 }).notNull(),
 })
 
 export const territories = pgTable("territories", {
-  territoryID: varchar("territory_id").notNull().primaryKey(),
-  territoryName: varchar("territory_name").notNull(),
+  territoryID: uuid("territory_id").primaryKey().default(sql`uuidv7()`),
+  territoryName: varchar("territory_name").notNull().unique(),
   available: boolean("available").notNull().default(true),
 })
 
 export const transporters = pgTable("transporters", {
-  transporterID: varchar("transporter_id").notNull().primaryKey(),
+  transporterID: uuid("transporter_id").primaryKey().default(sql`uuidv7()`),
   transporterName: varchar("transporter_name").notNull(),
   available: boolean("available").notNull().default(true),
 })
@@ -50,20 +51,18 @@ export const transporters = pgTable("transporters", {
 export const products = pgTable(
   "products",
   {
-    productID: varchar("product_id").notNull().primaryKey(),
+    productID: uuid("product_id").primaryKey().default(sql`uuidv7()`),
     productName: varchar("product_name").notNull(),
-    categoryID: varchar("category_id")
+    categoryID: uuid("category_id")
       .notNull()
-      .references(() => categories.categoryID),
-    originID: varchar("origin_id")
+      .references(() => categories.categoryID, { onDelete: "restrict", onUpdate: "cascade" }),
+    originID: uuid("origin_id")
       .notNull()
-      .references(() => origins.originID),
-    territoryID: varchar("territory_id")
+      .references(() => origins.originID, { onDelete: "restrict", onUpdate: "cascade" }),
+    territoryID: uuid("territory_id")
       .notNull()
-      .references(() => territories.territoryID),
-    taxID: varchar("tax_id")
-      .notNull()
-      .references(() => taxes.taxID),
+      .references(() => territories.territoryID, { onDelete: "restrict", onUpdate: "cascade" }),
+    available: boolean("available").notNull().default(true),
     createdAt: timestamp("created_at", { mode: "date" }).defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" })
       .defaultNow()
@@ -73,30 +72,29 @@ export const products = pgTable(
     index("products_categoryID_idx").on(table.categoryID),
     index("products_originID_idx").on(table.originID),
     index("products_territoryID_idx").on(table.territoryID),
-    index("products_taxID_idx").on(table.taxID),
   ],
 )
 
 export const templates = pgTable("templates", {
-  templateID: varchar("template_id").notNull().primaryKey(),
-  templateName: varchar("template_name").notNull(),
+  templateID: uuid("template_id").primaryKey().default(sql`uuidv7()`),
+  templateName: varchar("template_name").notNull().unique(),
 })
 
 export const templateProducts = pgTable(
   "template_products",
   {
-    templateID: varchar("template_id")
+    templateID: uuid("template_id")
       .notNull()
-      .references(() => templates.templateID),
-    productID: varchar("product_id")
+      .references(() => templates.templateID, { onDelete: "cascade", onUpdate: "cascade" }),
+    productID: uuid("product_id")
       .notNull()
-      .references(() => products.productID),
+      .references(() => products.productID, { onDelete: "cascade", onUpdate: "cascade" }),
   },
   (table) => [primaryKey({ columns: [table.templateID, table.productID] })],
 )
 
 export const CategoriesRelations = relations(categories, ({ one, many }) => ({
-  taxes: one(taxes, {
+  tax: one(taxes, {
     fields: [categories.taxID],
     references: [taxes.taxID],
   }),
@@ -109,7 +107,6 @@ export const OriginsRelations = relations(origins, ({ many }) => ({
 
 export const TaxesRelations = relations(taxes, ({ many }) => ({
   categories: many(categories),
-  products: many(products),
 }))
 
 export const TerritoriesRelations = relations(territories, ({ many }) => ({
@@ -128,10 +125,6 @@ export const ProductsRelations = relations(products, ({ one, many }) => ({
   territory: one(territories, {
     fields: [products.territoryID],
     references: [territories.territoryID],
-  }),
-  tax: one(taxes, {
-    fields: [products.taxID],
-    references: [taxes.taxID],
   }),
   templateProducts: many(templateProducts),
 }))


### PR DESCRIPTION
Use the default [`uuidv7()` function](https://www.postgresql.org/docs/current/functions-uuid.html), introduced in PostgreSQL 18, to generate UUIDv7 primary keys