### PR TITLE
feat(api): integrate `ServiceErrors` across all controllers/services + VineJS handler

### DIFF
--- a/apps/api/app/controllers/GetProductTaxesController.ts
+++ b/apps/api/app/controllers/GetProductTaxesController.ts
@@ -1,12 +1,13 @@
 import type { HttpContext } from "@adonisjs/core/http"
-import type { TaxSimulatorResult, Territory } from "@taxdom/types"
 import logger from "@adonisjs/core/services/logger"
+import type { TaxSimulatorResult, Territory } from "@taxdom/types"
 import { and, eq } from "drizzle-orm"
 
 import { db } from "#config/database"
 import { categories, products, taxes } from "#database/schema"
-import { GetProductTaxeValidator } from "#validators/GetProductTaxeValidator"
+import { NotFoundError } from "#exceptions/ServiceErrors"
 import { isEUCountry } from "#lib/isEU"
+import { GetProductTaxeValidator } from "#validators/GetProductTaxeValidator"
 
 const territoryMap: Record<Territory, number> = {
   CORSE: 1,
@@ -26,9 +27,8 @@ export default class GetProductTaxeController {
     const origin = payload.origin.toUpperCase()
     const territory = payload.territory.toUpperCase() as Territory
 
-    // Déterminer si le pays d'origine fait partie de l'UE
     const isEU = isEUCountry(origin)
-    const originID = isEU ? 1 : 2 // 1 pour EU, 2 pour HORS_EU
+    const originID = isEU ? 1 : 2
 
     try {
       const result = await db
@@ -51,7 +51,7 @@ export default class GetProductTaxeController {
       if (result.length === 0) {
         logger.error("[PRODUCT NOT FOUND] Fetching (%s) taxes in getProductTaxeController", product)
 
-        return { error: "Product not found" }
+        throw new NotFoundError(`Aucune taxe trouvée pour le produit "${product}"`)
       }
 
       logger.info("Fetching (%s) taxes in getProductTaxeController", product)
@@ -59,15 +59,16 @@ export default class GetProductTaxeController {
       const res: TaxSimulatorResult = {
         product,
         taxes: {
-          tva: result[0].tva,
-          om: result[0].om,
-          omr: result[0].omr,
+          tva: Number(result[0].tva),
+          om: Number(result[0].om),
+          omr: Number(result[0].omr),
         },
       }
 
       return res
     } catch (err) {
-      logger.error({ err: err }, "Cannot getProductTaxes")
+      logger.error({ err }, "Cannot getProductTaxes")
+      throw err
     }
   }
 }

--- a/apps/api/app/controllers/GetTemplatesController.ts
+++ b/apps/api/app/controllers/GetTemplatesController.ts
@@ -1,31 +1,37 @@
-import { db } from "#config/database"
 import logger from "@adonisjs/core/services/logger"
+import { db } from "#config/database"
+import { InternalServerError } from "#exceptions/ServiceErrors"
 
 export default class GetTemplatesController {
   async handle() {
-    const allTemplatesWithProducts = await db.query.templates.findMany({
-      with: {
-        templateProducts: {
-          with: {
-            product: {
-              columns: {
-                productID: true,
-                productName: true,
+    try {
+      const allTemplatesWithProducts = await db.query.templates.findMany({
+        with: {
+          templateProducts: {
+            with: {
+              product: {
+                columns: {
+                  productID: true,
+                  productName: true,
+                },
               },
             },
           },
         },
-      },
-    })
+      })
 
-    const formatted = allTemplatesWithProducts.map((template) => ({
-      templateID: template.templateID,
-      templateName: template.templateName,
-      products: template.templateProducts.map((p) => p.product),
-    }))
+      const formatted = allTemplatesWithProducts.map((template) => ({
+        templateID: template.templateID,
+        templateName: template.templateName,
+        products: template.templateProducts.map((p) => p.product),
+      }))
 
-    logger.info("Get all templates")
+      logger.info("Get all templates")
 
-    return formatted
+      return formatted
+    } catch (err) {
+      logger.error({ err }, "Failed to get templates")
+      throw new InternalServerError("Erreur lors de la récupération des templates")
+    }
   }
 }

--- a/apps/api/app/controllers/SearchProductsController.ts
+++ b/apps/api/app/controllers/SearchProductsController.ts
@@ -1,7 +1,9 @@
 import type { HttpContext } from "@adonisjs/core/http"
 import logger from "@adonisjs/core/services/logger"
-import { sql } from "drizzle-orm"
+import { ilike } from "drizzle-orm"
 import { db } from "#config/database"
+import { products } from "#database/schema"
+import { BadRequestError, NotFoundError } from "#exceptions/ServiceErrors"
 import { SearchProductsValidator } from "#validators/SearchProductsValidator"
 
 export default class SearchProductsController {
@@ -10,24 +12,22 @@ export default class SearchProductsController {
     const productName = filters.name.trim()
 
     if (!productName) {
-      return { error: "Product name is required" }
+      throw new BadRequestError("Product name is required")
     }
 
-    const result = await db.run(sql`
-      SELECT DISTINCT p.product_name
-      FROM products p
-      JOIN products_fts fts ON p.product_id = fts.rowid
-      WHERE products_fts MATCH ${`${productName}*`}
-      ORDER BY rank
-      LIMIT 10;
-    `)
+    const result = await db
+      .selectDistinct({ name: products.productName })
+      .from(products)
+      .where(ilike(products.productName, `${productName}%`))
+      .orderBy(products.productName)
+      .limit(10)
 
-    if (!result.rows.length) {
-      return { error: "No product found" }
+    if (!result.length) {
+      throw new NotFoundError("No product found")
     }
 
     logger.info("Fetching (%s) productName in searchProductNameController", productName)
 
-    return result.rows.map((row) => ({ name: row.product_name as string }))
+    return result.map((row) => ({ name: row.name }))
   }
 }

--- a/apps/api/app/controllers/TerritoriesController.ts
+++ b/apps/api/app/controllers/TerritoriesController.ts
@@ -24,8 +24,12 @@ export default class TerritoriesController {
     return await this.territoryService.findTopByProductCount()
   }
 
-  async show({ response }: HttpContext) {
-    return response.status(404)
+  async show({ params }: HttpContext) {
+    const territoryIdParam: string = params.id
+    if (!territoryIdParam) {
+      throw new BadRequestError("Paramètre manquant")
+    }
+    return this.territoryService.findById(territoryIdParam)
   }
 
   async store({ request, response }: HttpContext) {

--- a/apps/api/app/exceptions/ServiceErrors.ts
+++ b/apps/api/app/exceptions/ServiceErrors.ts
@@ -1,0 +1,43 @@
+import ApplicationException from "./ApplicationException.js"
+
+export class BadRequestError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 400, "BAD_REQUEST")
+  }
+}
+
+export class ConflictError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 409, "CONFLICT")
+  }
+}
+
+export class NotFoundError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 404, "NOT_FOUND")
+  }
+}
+
+export class ValidationError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 422, "VALIDATION_ERROR")
+  }
+}
+
+export class UnauthorizedError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 401, "UNAUTHORIZED")
+  }
+}
+
+export class ForbiddenError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 403, "FORBIDDEN")
+  }
+}
+
+export class InternalServerError extends ApplicationException {
+  constructor(message: string) {
+    super(message, 500, "INTERNAL_ERROR")
+  }
+}

--- a/apps/api/app/exceptions/handler.ts
+++ b/apps/api/app/exceptions/handler.ts
@@ -1,5 +1,6 @@
 import { ExceptionHandler, type HttpContext } from "@adonisjs/core/http"
 import app from "@adonisjs/core/services/app"
+import { errors as vineJSErrors } from "@vinejs/vine"
 
 export default class HttpExceptionHandler extends ExceptionHandler {
   /**
@@ -9,10 +10,41 @@ export default class HttpExceptionHandler extends ExceptionHandler {
   protected debug = !app.inProduction
 
   /**
+   * HTTP status codes that should not be reported to the logger.
+   * These are client errors that don't indicate server problems.
+   */
+  protected ignoreStatuses = [400, 401, 403, 404, 409, 422]
+
+  /**
+   * Error codes that should not be reported to the logger.
+   * These are application-specific codes for expected error conditions.
+   */
+  protected ignoreCodes = [
+    "BAD_REQUEST",
+    "UNAUTHORIZED",
+    "FORBIDDEN",
+    "NOT_FOUND",
+    "CONFLICT",
+    "VALIDATION_ERROR",
+    "E_VALIDATION_ERROR",
+  ]
+
+  /**
    * The method is used for handling errors and returning
    * response to the client
    */
   async handle(error: unknown, ctx: HttpContext) {
+    if (error instanceof vineJSErrors.E_VALIDATION_ERROR) {
+      ctx.response.status(422).send({
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          messages: error.messages.messages,
+        },
+      })
+      return
+    }
+
     return super.handle(error, ctx)
   }
 

--- a/apps/api/app/services/OriginService.ts
+++ b/apps/api/app/services/OriginService.ts
@@ -5,7 +5,7 @@ import { v7 as uuidv7 } from "uuid"
 
 import type * as schema from "#database/schema"
 import { origins, products } from "#database/schema"
-import { ConflictError, NotFoundError } from "#exceptions/ServiceErrors"
+import { BadRequestError, ConflictError, NotFoundError } from "#exceptions/ServiceErrors"
 
 type DB = NodePgDatabase<typeof schema>
 
@@ -157,7 +157,7 @@ export class OriginService {
     }
 
     if (Object.keys(updateData).length === 0) {
-      throw new Error("Aucune donnée à mettre à jour")
+      throw new BadRequestError("Aucune donnée à mettre à jour")
     }
 
     const [updated] = await this.db

--- a/apps/api/app/services/ParcelCalculationService.ts
+++ b/apps/api/app/services/ParcelCalculationService.ts
@@ -4,6 +4,7 @@ import type { NodePgDatabase } from "drizzle-orm/node-postgres"
 
 import type * as schema from "#database/schema"
 import { categories, products as productsTable, taxes } from "#database/schema"
+import { NotFoundError } from "#exceptions/ServiceErrors"
 
 type DB = NodePgDatabase<typeof schema>
 
@@ -134,7 +135,11 @@ export class ParcelCalculationService {
       omr: Number(result.omr),
     }))
 
-    const { tva, om, omr } = availableCategories[0] ?? { tva: 0, om: 0, omr: 0 }
+    if (availableCategories.length === 0) {
+      throw new NotFoundError("Aucun produit trouvé pour le calcul de taxes")
+    }
+
+    const { tva, om, omr } = availableCategories[0]
 
     const omrPrice = Math.round((dutyPrice * omr) / 100)
     const omPrice = Math.round((dutyPrice * om) / 100)

--- a/apps/api/app/services/ProductService.ts
+++ b/apps/api/app/services/ProductService.ts
@@ -35,7 +35,7 @@ type ProductQueryResult = InferSelectModel<typeof products> & {
 function toDecimalNumber(value: unknown): number {
   const num = Number(value)
   if (Number.isNaN(num)) {
-    throw new Error(`Invalid decimal value: ${String(value)}`)
+    throw new BadRequestError(`Invalid decimal value: ${String(value)}`)
   }
   return num
 }

--- a/apps/api/app/services/TerritoryService.ts
+++ b/apps/api/app/services/TerritoryService.ts
@@ -5,7 +5,7 @@ import { v7 as uuidv7 } from "uuid"
 
 import type * as schema from "#database/schema"
 import { products, territories } from "#database/schema"
-import { ConflictError, NotFoundError } from "#exceptions/ServiceErrors"
+import { BadRequestError, ConflictError, NotFoundError } from "#exceptions/ServiceErrors"
 
 type DB = NodePgDatabase<typeof schema>
 
@@ -109,6 +109,22 @@ export class TerritoryService {
     }
   }
 
+  async findById(territoryId: string): Promise<Territory> {
+    const territory = await this.db.query.territories.findFirst({
+      where: eq(territories.territoryID, territoryId),
+    })
+
+    if (!territory) {
+      throw new NotFoundError("Territoire non trouvé")
+    }
+
+    return {
+      territoryID: territory.territoryID,
+      territoryName: territory.territoryName,
+      available: territory.available,
+    }
+  }
+
   async create(input: CreateTerritoryInput): Promise<Territory> {
     const trimmedName = input.territoryName.trim().toUpperCase()
 
@@ -148,7 +164,7 @@ export class TerritoryService {
     }
 
     if (Object.keys(updateData).length === 0) {
-      throw new Error("Aucune donnée à mettre à jour")
+      throw new BadRequestError("Aucune donnée à mettre à jour")
     }
 
     const [updated] = await this.db


### PR DESCRIPTION
Standardize error handling across the API by using `ServiceErrors` (BadRequestError, NotFoundError, ConflictError, etc.) instead of raw `throw new Error()` or `return { error }`. This ensures a consistent `{ success: false, error: { code, message } }` response format for all business errors.

## Response format
### Standard business error
```json
{
  "success": false,
  "error": {
    "code": "NOT_FOUND",
    "message": "Product not found"
  }
}
```
### VineJS validation error

```json
{
  "success": false,
  "error": {
    "code": "VALIDATION_ERROR",
    "messages": [
      { "field": "name", "message": "required", "rule": "required" }
    ]
  }
}
```