### PR TITLE
  refactor(forms/select): accessibility, state model rewrite & portal context

### DIFF
--- a/apps/dashboard/src/components/Forms/Select/BaseSelect.tsx
+++ b/apps/dashboard/src/components/Forms/Select/BaseSelect.tsx
@@ -3,7 +3,9 @@ import * as m from "motion/react-m"
 import {
   type InputHTMLAttributes,
   type KeyboardEvent,
+  useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -13,6 +15,7 @@ import { createPortal } from "react-dom"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
 import { OptionsList } from "./OptionsList"
 import { HintText, LoadingCircle } from "./Select.styled"
+import { useSelectPortalContainer } from "./SelectPortalContext"
 
 export interface BaseOption {
   name: string
@@ -22,7 +25,7 @@ export interface BaseOption {
 
 type NativeInputProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  "onChange" | "value" | "defaultValue" | "children"
+  "onChange" | "value" | "defaultValue" | "children" | "role"
 >
 
 export interface BaseSelectProps extends NativeInputProps {
@@ -43,13 +46,13 @@ export interface BaseSelectProps extends NativeInputProps {
 }
 
 export default function BaseSelect({
-  id,
+  id: idProp,
   name,
   label,
   placeholder,
   hint,
   options = [],
-  value = "",
+  value,
   onChange,
   onBlur,
   onFocus,
@@ -59,159 +62,238 @@ export default function BaseSelect({
   required,
   ...inputProps
 }: BaseSelectProps) {
-  const selectedIndexRef = useRef(0)
+  const reactId = useId()
+  const inputId = idProp ?? name ?? reactId
+  const listboxId = `${inputId}-listbox`
+  const hintId = `${inputId}-hint`
+
   const inputRef = useRef<HTMLInputElement>(null)
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const [show, setShow] = useState(false)
-  const [searchValue, setSearchValue] = useState("")
+  const containerRef = useRef<HTMLDivElement>(null)
+  const ignoreBlurRef = useRef(false)
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [inputValue, setInputValue] = useState("")
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  const portalContainer = useSelectPortalContainer()
+  const portalTarget = portalContainer ?? (typeof document !== "undefined" ? document.body : null)
+
   const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0, width: 0 })
 
+  const selectedIndex = options.findIndex((option) => (option.value ?? option.name) === value)
+
   useEffect(() => {
-    if (value) {
-      const selected = options.find((o) => o.value === value || o.name === value)
-      setSearchValue(selected?.name ?? value)
-    } else {
-      setSearchValue("")
-    }
+    const selected = options.find((option) => (option.value ?? option.name) === value)
+    setInputValue(selected?.name ?? "")
   }, [value, options])
 
-  useEffect(() => {
-    selectedIndexRef.current = selectedIndex
+  const filteredOptions = options.filter((option) => {
+    if (!inputValue) return true
+    return option.name.toLowerCase().includes(inputValue.toLowerCase())
+  })
+
+  const openListbox = useCallback(() => {
+    setIsOpen(true)
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0)
   }, [selectedIndex])
 
+  const closeListbox = useCallback(() => {
+    setIsOpen(false)
+    setActiveIndex(-1)
+  }, [])
+
+  const selectOption = useCallback(
+    (option: BaseOption) => {
+      onChange(option.value ?? option.name)
+      setInputValue(option.name)
+      closeListbox()
+      inputRef.current?.focus()
+    },
+    [onChange, closeListbox],
+  )
+
   useLayoutEffect(() => {
-    if (show && inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect()
+    if (!isOpen || !inputRef.current) return
+
+    const rect = inputRef.current.getBoundingClientRect()
+    if (portalContainer) {
+      const containerRect = portalContainer.getBoundingClientRect()
       setDropdownPos({
-        top: rect.bottom,
-        left: rect.left,
+        top: rect.bottom - containerRect.top,
+        left: rect.left - containerRect.left,
+        width: rect.width,
+      })
+    } else {
+      setDropdownPos({
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
         width: rect.width,
       })
     }
-  }, [show])
+  }, [isOpen, portalContainer])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleClickOutside = (event: globalThis.MouseEvent) => {
+      const target = event.target as Node
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(target) &&
+        !document.getElementById(listboxId)?.contains(target)
+      ) {
+        closeListbox()
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [isOpen, listboxId, closeListbox])
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
-    setSearchValue(newValue)
-    setSelectedIndex(0)
-    if (!show) setShow(true)
-  }
-
-  const handleSelect = (selectedValue: string) => {
-    onChange(selectedValue)
-    setShow(false)
+    setInputValue(newValue)
+    if (!isOpen) openListbox()
+    setActiveIndex(0)
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (options?.length === 0) return
-
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+    if (e.altKey && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
       e.preventDefault()
-      setSelectedIndex((prevIndex) => {
-        const filteredOptions = options.filter((option) => {
-          const lowerCaseValue = searchValue.toLowerCase()
-          const exactMatchFound =
-            lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-          const lowerCaseOption = option.name.toLowerCase()
-          return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-        })
+      if (e.key === "ArrowDown") openListbox()
+      else closeListbox()
+      return
+    }
 
-        if (filteredOptions.length === 0) return prevIndex
-
-        const newIndex =
-          e.key === "ArrowUp"
-            ? (prevIndex - 1 + filteredOptions.length) % filteredOptions.length
-            : (prevIndex + 1) % filteredOptions.length
-        selectedIndexRef.current = newIndex
-        return newIndex
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      if (!isOpen) {
+        openListbox()
+        return
+      }
+      setActiveIndex((prev) => {
+        const max = filteredOptions.length - 1
+        if (max < 0) return -1
+        if (e.key === "ArrowDown") return prev >= max ? 0 : prev + 1
+        return prev <= 0 ? max : prev - 1
       })
+      return
+    }
+
+    if (e.key === "Home" && isOpen) {
+      e.preventDefault()
+      setActiveIndex(0)
+      return
+    }
+
+    if (e.key === "End" && isOpen) {
+      e.preventDefault()
+      setActiveIndex(filteredOptions.length - 1)
+      return
     }
 
     if (e.key === "Enter") {
       e.preventDefault()
-      const filteredOptions = options.filter((option) => {
-        const lowerCaseValue = searchValue.toLowerCase()
-        const exactMatchFound =
-          lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-        const lowerCaseOption = option.name.toLowerCase()
-        return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-      })
-
-      const selectedOption = filteredOptions[selectedIndexRef.current]
-      if (selectedOption) {
-        handleSelect(selectedOption.name)
+      if (isOpen && activeIndex >= 0 && activeIndex < filteredOptions.length) {
+        selectOption(filteredOptions[activeIndex])
+      } else if (!isOpen) {
+        openListbox()
       }
+      return
     }
 
     if (e.key === "Escape") {
-      setShow(false)
+      e.preventDefault()
+      closeListbox()
     }
   }
 
-  const hintId = id ? `${id}-hint` : undefined
+  const handleBlur = () => {
+    if (ignoreBlurRef.current) {
+      ignoreBlurRef.current = false
+      inputRef.current?.focus()
+      return
+    }
+    closeListbox()
+    onBlur?.()
+  }
+
+  const handleOptionMouseDown = () => {
+    ignoreBlurRef.current = true
+  }
+
+  const handleFocus = useCallback(() => {
+    openListbox()
+    onFocus?.()
+  }, [openListbox, onFocus])
+
+  const activeOptionId =
+    isOpen && activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
 
   return (
-    <InputContainer>
-      <label htmlFor={id || name}>
+    <InputContainer ref={containerRef}>
+      <label htmlFor={inputId}>
         {label}
-        {required && " *"}
-        {errors.length > 0 && <span> {errors.join(", ")}</span>}
+        {required ? " *" : null}
+        {errors.length > 0 && <span>{errors.join(", ")}</span>}
       </label>
       <input
         ref={inputRef}
         {...inputProps}
-        id={id || name}
+        id={inputId}
         name={name}
+        role="combobox"
         autoComplete="off"
-        onChange={handleInputChange}
-        onBlur={() => {
-          setTimeout(() => {
-            setShow(false)
-            onBlur?.()
-          }, 120)
-        }}
-        onFocus={() => {
-          setShow(true)
-          onFocus?.()
-        }}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        value={searchValue}
-        disabled={disabled}
-        required={required}
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={activeOptionId}
         aria-required={required}
         aria-invalid={errors.length > 0}
-        aria-describedby={hint && hintId ? hintId : undefined}
+        aria-describedby={hint ? hintId : undefined}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        value={inputValue}
+        disabled={disabled}
+        readOnly={disabled}
+        required={required}
       />
-      {loading && <LoadingCircle />}
-      {hint && <HintText id={hintId}>{hint}</HintText>}
-      {createPortal(
-        <AnimatePresence>
-          {options.length > 0 && show && (
-            <m.div
-              style={{
-                position: "fixed",
-                top: dropdownPos.top,
-                left: dropdownPos.left,
-                width: dropdownPos.width,
-                zIndex: 9999,
-              }}
-              initial={{ translateY: "-5px", opacity: 0 }}
-              animate={{ translateY: "0", opacity: 1 }}
-              exit={{ translateY: "5px", opacity: 0 }}
-            >
-              <OptionsList
-                options={options}
-                value={searchValue}
-                onSelect={handleSelect}
-                selectedIndex={selectedIndex}
-                setSelectedIndex={setSelectedIndex}
-              />
-            </m.div>
-          )}
-        </AnimatePresence>,
-        document.body,
-      )}
+      {loading ? <LoadingCircle /> : null}
+      {hint ? <HintText id={hintId}>{hint}</HintText> : null}
+      {portalTarget
+        ? createPortal(
+            <AnimatePresence>
+              {filteredOptions.length > 0 && isOpen && (
+                <m.div
+                  style={{
+                    position: portalContainer ? "absolute" : "fixed",
+                    top: dropdownPos.top,
+                    left: dropdownPos.left,
+                    width: dropdownPos.width,
+                    zIndex: 9999,
+                  }}
+                  initial={{ translateY: "-5px", opacity: 0 }}
+                  animate={{ translateY: "0", opacity: 1 }}
+                  exit={{ translateY: "5px", opacity: 0 }}
+                >
+                  <OptionsList
+                    options={filteredOptions}
+                    listboxId={listboxId}
+                    activeIndex={activeIndex}
+                    selectedIndex={selectedIndex}
+                    onSelect={selectOption}
+                    onMouseDown={handleOptionMouseDown}
+                  />
+                </m.div>
+              )}
+            </AnimatePresence>,
+            portalTarget,
+          )
+        : null}
     </InputContainer>
   )
 }

--- a/apps/dashboard/src/components/Forms/Select/OptionsList.tsx
+++ b/apps/dashboard/src/components/Forms/Select/OptionsList.tsx
@@ -1,57 +1,112 @@
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { type Dispatch, type SetStateAction, useMemo, useRef } from "react"
+import { type MouseEvent, useCallback, useEffect, useRef } from "react"
+
 import type { BaseOption } from "./BaseSelect"
 import { NonVirtualItem, VirtualItem, VirtualizerContainer } from "./OptionsList.styled"
 import { OptionContainer } from "./Select.styled"
 
 interface OptionsListProps {
   options: BaseOption[]
-  value: string
-  onSelect: (value: string) => void
+  listboxId: string
+  activeIndex: number
   selectedIndex: number
-  setSelectedIndex: Dispatch<SetStateAction<number>>
+  onSelect: (option: BaseOption) => void
+  onMouseDown?: () => void
+}
+
+interface OptionItemProps {
+  option: BaseOption
+  id: string
+  isSelected: boolean
+  isActive: boolean
+  optionIndex: number
+  onMouseDown?: () => void
+  onSelect: (option: BaseOption) => void
+  style?: React.CSSProperties
+  virtual?: boolean
+}
+
+const itemHeight = 35
+const maxVisibleItems = 6
+
+function OptionItem({
+  option,
+  id,
+  isSelected,
+  isActive,
+  optionIndex,
+  onMouseDown,
+  onSelect,
+  style,
+  virtual,
+}: OptionItemProps) {
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      event.preventDefault()
+      onSelect(option)
+    },
+    [onSelect, option],
+  )
+
+  const commonProps = {
+    id,
+    role: "option" as const,
+    "aria-selected": isSelected,
+    "data-option-index": optionIndex,
+    "data-selected": isActive,
+    "data-available": option.available,
+    onMouseDown,
+    onClick: handleClick,
+    style,
+  }
+
+  if (virtual) {
+    return <VirtualItem {...commonProps}>{option.name}</VirtualItem>
+  }
+
+  return <NonVirtualItem {...commonProps}>{option.name}</NonVirtualItem>
 }
 
 export function OptionsList({
   options,
-  value,
-  onSelect,
+  listboxId,
+  activeIndex,
   selectedIndex,
-  setSelectedIndex,
+  onSelect,
+  onMouseDown,
 }: OptionsListProps) {
   const parentRef = useRef<HTMLUListElement>(null)
-  const itemHeight = 35
-  const maxVisibleItems = 6
 
-  const filteredOptions = useMemo(() => {
-    return options.filter((option) => {
-      const lowerCaseValue = value.toLowerCase()
-      const exactMatchFound =
-        lowerCaseValue && options.some((opt) => opt.name.toLowerCase() === lowerCaseValue)
-      const lowerCaseOption = option.name.toLowerCase()
-      return !exactMatchFound && lowerCaseOption.includes(lowerCaseValue)
-    })
-  }, [options, value])
-
-  const shouldVirtualize = filteredOptions.length > maxVisibleItems
+  const shouldVirtualize = options.length > maxVisibleItems
 
   const containerHeight = shouldVirtualize
     ? maxVisibleItems * itemHeight
-    : filteredOptions.length * itemHeight
+    : options.length * itemHeight
 
   const virtualizer = useVirtualizer({
-    count: filteredOptions.length,
+    count: options.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => itemHeight,
     overscan: 5,
   })
 
-  if (filteredOptions.length === 0) return null
+  useEffect(() => {
+    if (!parentRef.current || activeIndex < 0 || activeIndex >= options.length) return
+
+    const activeElement = parentRef.current.querySelector(`[data-option-index="${activeIndex}"]`)
+    activeElement?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex, options.length])
+
+  if (options.length === 0) return null
+
+  const optionId = (index: number) => `${listboxId}-option-${index}`
 
   return (
     <OptionContainer
       ref={parentRef}
-      aria-label="Liste déroulante"
+      id={listboxId}
+      role="listbox"
+      aria-label="Suggestions"
       style={{
         height: `${containerHeight}px`,
         overflow: shouldVirtualize ? "auto" : "hidden",
@@ -64,39 +119,38 @@ export function OptionsList({
           }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
-            const option = filteredOptions[virtualItem.index]
+            const option = options[virtualItem.index]
             return (
-              <VirtualItem
-                key={option.name}
-                data-selected={virtualItem.index === selectedIndex}
-                data-available={option.available}
-                onMouseDown={() => onSelect(option.name)}
-                onMouseEnter={() => {
-                  setSelectedIndex(virtualItem.index)
-                }}
+              <OptionItem
+                key={option.value ?? option.name}
+                option={option}
+                id={optionId(virtualItem.index)}
+                isSelected={virtualItem.index === selectedIndex}
+                isActive={virtualItem.index === activeIndex}
+                optionIndex={virtualItem.index}
+                onMouseDown={onMouseDown}
+                onSelect={onSelect}
                 style={{
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
-              >
-                {option.name}
-              </VirtualItem>
+                virtual
+              />
             )
           })}
         </VirtualizerContainer>
       ) : (
-        filteredOptions.map((option, index) => (
-          <NonVirtualItem
-            key={option.name}
-            data-selected={index === selectedIndex}
-            data-available={option.available}
-            onMouseDown={() => onSelect(option.name)}
-            onMouseEnter={() => {
-              setSelectedIndex(index)
-            }}
-          >
-            {option.name}
-          </NonVirtualItem>
+        options.map((option, index) => (
+          <OptionItem
+            key={option.value ?? option.name}
+            option={option}
+            id={optionId(index)}
+            isSelected={index === selectedIndex}
+            isActive={index === activeIndex}
+            optionIndex={index}
+            onMouseDown={onMouseDown}
+            onSelect={onSelect}
+          />
         ))
       )}
     </OptionContainer>

--- a/apps/dashboard/src/components/Forms/Select/Select.styled.tsx
+++ b/apps/dashboard/src/components/Forms/Select/Select.styled.tsx
@@ -4,7 +4,7 @@ export const HintText = styled.span`
   display: block;
   font-size: 0.75rem;
   font-family: token(fonts.nativeFont);
-  color: token(colors.darkGray);
+  color: token(colors.border);
   margin-top: 4px;
   line-height: 1.4;
 `
@@ -29,7 +29,7 @@ export const OptionContainer = styled.ul`
   top: calc(100% + 6px);
   z-index: 1;
   position: absolute;
-  border: 1px solid token(colors.darkGray);
+  border: 1px solid token(colors.border);
   background: token(colors.background);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
   overflow: hidden;

--- a/apps/dashboard/src/components/Forms/Select/SelectPortalContext.tsx
+++ b/apps/dashboard/src/components/Forms/Select/SelectPortalContext.tsx
@@ -1,0 +1,5 @@
+import { createContext, useContext } from "react"
+
+export const SelectPortalContainerContext = createContext<HTMLElement | null>(null)
+
+export const useSelectPortalContainer = () => useContext(SelectPortalContainerContext)

--- a/apps/web/src/components/Forms/Select/BaseSelect.tsx
+++ b/apps/web/src/components/Forms/Select/BaseSelect.tsx
@@ -1,27 +1,32 @@
 "use client"
 
 import { useVirtualizer } from "@tanstack/react-virtual"
+import type { SelectOption } from "@taxdom/types"
 import { AnimatePresence } from "motion/react"
 import * as m from "motion/react-m"
 import {
+  type InputHTMLAttributes,
+  type KeyboardEvent,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
-  type InputHTMLAttributes,
-  type KeyboardEvent,
 } from "react"
-
-import type { SelectOption } from "@taxdom/types"
-
-import { useDebounce } from "@/hooks/useDebounce"
 import { InputContainer } from "@/components/Forms/Input/Input.styled"
-import { LoadingCircle, OptionContainer } from "./Select.styled"
+import { useDebounce } from "@/hooks/useDebounce"
+import {
+  LoadingCircle,
+  NonVirtualItem,
+  OptionContainer,
+  VirtualItem,
+  VirtualizerContainer,
+} from "./Select.styled"
 
 type NativeInputProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  "onChange" | "value" | "defaultValue" | "children"
+  "onChange" | "value" | "defaultValue" | "children" | "role"
 >
 
 export interface BaseSelectProps extends NativeInputProps {
@@ -35,6 +40,8 @@ export interface BaseSelectProps extends NativeInputProps {
   onBlur?: () => void
   onFocus?: () => void
   onSearch?: (query: string) => Promise<SelectOption[]>
+  searchDebounceMs?: number
+  searchMinChars?: number
   loading?: boolean
   errors?: string[]
   disabled?: boolean
@@ -44,18 +51,79 @@ export interface BaseSelectProps extends NativeInputProps {
 
 interface OptionsListProps {
   options: SelectOption[]
-  onSelect: (value: string) => void
+  listboxId: string
+  activeIndex: number
   selectedIndex: number
-  setSelectedIndex: (index: number) => void
+  onSelect: (option: SelectOption) => void
+  onMouseDown?: () => void
 }
 
-const OptionsList = ({ options, onSelect, selectedIndex, setSelectedIndex }: OptionsListProps) => {
+interface OptionItemProps {
+  option: SelectOption
+  id: string
+  isSelected: boolean
+  isActive: boolean
+  optionIndex: number
+  onMouseDown?: () => void
+  onSelect: (option: SelectOption) => void
+  style?: React.CSSProperties
+  virtual?: boolean
+}
+
+const itemHeight = 35
+const maxVisibleItems = 6
+const defaultSearchMinChars = 2
+const defaultSearchDebounceMs = 300
+
+function OptionItem({
+  option,
+  id,
+  isSelected,
+  isActive,
+  optionIndex,
+  onMouseDown,
+  onSelect,
+  style,
+  virtual,
+}: OptionItemProps) {
+  const handleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault()
+      onSelect(option)
+    },
+    [onSelect, option],
+  )
+
+  const commonProps = {
+    id,
+    role: "option" as const,
+    "aria-selected": isSelected,
+    "data-option-index": optionIndex,
+    "data-selected": isActive,
+    "data-available": option.available,
+    onMouseDown,
+    onClick: handleClick,
+    style,
+  }
+
+  if (virtual) {
+    return <VirtualItem {...commonProps}>{option.name}</VirtualItem>
+  }
+
+  return <NonVirtualItem {...commonProps}>{option.name}</NonVirtualItem>
+}
+
+function OptionsList({
+  options,
+  listboxId,
+  activeIndex,
+  selectedIndex,
+  onSelect,
+  onMouseDown,
+}: OptionsListProps) {
   const parentRef = useRef<HTMLUListElement>(null)
-  const itemHeight = 35
-  const maxVisibleItems = 6
 
   const shouldVirtualize = options.length > maxVisibleItems
-
   const containerHeight = shouldVirtualize
     ? maxVisibleItems * itemHeight
     : options.length * itemHeight
@@ -67,71 +135,72 @@ const OptionsList = ({ options, onSelect, selectedIndex, setSelectedIndex }: Opt
     overscan: 5,
   })
 
+  useEffect(() => {
+    if (!parentRef.current || activeIndex < 0 || activeIndex >= options.length) return
+    const activeElement = parentRef.current.querySelector(`[data-option-index="${activeIndex}"]`)
+    activeElement?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex, options.length])
+
   if (options.length === 0) return null
+
+  const optionId = (index: number) => `${listboxId}-option-${index}`
 
   return (
     <OptionContainer
       ref={parentRef}
-      aria-label="Liste déroulante"
+      id={listboxId}
+      role="listbox"
+      aria-label="Suggestions"
       style={{
         height: `${containerHeight}px`,
         overflow: shouldVirtualize ? "auto" : "hidden",
       }}
     >
       {shouldVirtualize ? (
-        <div
+        <VirtualizerContainer
           style={{
             height: `${virtualizer.getTotalSize()}px`,
-            width: "100%",
-            position: "relative",
           }}
         >
           {virtualizer.getVirtualItems().map((virtualItem) => {
             const option = options[virtualItem.index]
             return (
-              <li
-                key={option.name}
-                data-selected={virtualItem.index === selectedIndex}
-                data-available={option.available}
-                onClick={() => onSelect(option.value || option.name)}
-                onKeyUp={() => onSelect(option.value || option.name)}
-                onMouseEnter={() => {
-                  setSelectedIndex(virtualItem.index)
-                }}
+              <OptionItem
+                key={option.value ?? option.name}
+                option={option}
+                id={optionId(virtualItem.index)}
+                isSelected={virtualItem.index === selectedIndex}
+                isActive={virtualItem.index === activeIndex}
+                optionIndex={virtualItem.index}
+                onMouseDown={onMouseDown}
+                onSelect={onSelect}
                 style={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
                   height: `${virtualItem.size}px`,
                   transform: `translateY(${virtualItem.start}px)`,
                 }}
-              >
-                {option.name}
-              </li>
+                virtual
+              />
             )
           })}
-        </div>
+        </VirtualizerContainer>
       ) : (
         options.map((option, index) => (
-          <li
-            key={option.name}
-            data-selected={index === selectedIndex}
-            data-available={option.available}
-            onClick={() => onSelect(option.value || option.name)}
-            onKeyUp={() => onSelect(option.value || option.name)}
-            onMouseEnter={() => {
-              setSelectedIndex(index)
-            }}
+          <OptionItem
+            key={option.value ?? option.name}
+            option={option}
+            id={optionId(index)}
+            isSelected={index === selectedIndex}
+            isActive={index === activeIndex}
+            optionIndex={index}
+            onMouseDown={onMouseDown}
+            onSelect={onSelect}
             style={{
               height: `${itemHeight}px`,
               display: "flex",
               alignItems: "center",
               padding: "0 5px",
             }}
-          >
-            {option.name}
-          </li>
+          />
         ))
       )}
     </OptionContainer>
@@ -139,16 +208,18 @@ const OptionsList = ({ options, onSelect, selectedIndex, setSelectedIndex }: Opt
 }
 
 export default function BaseSelect({
-  id,
+  id: idProp,
   name,
   label,
   placeholder,
   options = [],
-  value = "",
+  value,
   onChange,
   onBlur,
   onFocus,
   onSearch,
+  searchDebounceMs = defaultSearchDebounceMs,
+  searchMinChars = defaultSearchMinChars,
   loading,
   errors = [],
   disabled,
@@ -156,21 +227,36 @@ export default function BaseSelect({
   noResultsMessage,
   ...inputProps
 }: BaseSelectProps) {
-  const selectedIndexRef = useRef(0)
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const [show, setShow] = useState(false)
+  const reactId = useId()
+  const inputId = idProp ?? name ?? reactId
+  const listboxId = `${inputId}-listbox`
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const ignoreBlurRef = useRef(false)
+
+  const isSearchMode = Boolean(onSearch)
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [inputValue, setInputValue] = useState(value)
+  const [activeIndex, setActiveIndex] = useState(-1)
   const [searchResults, setSearchResults] = useState<SelectOption[]>([])
   const [searchLoading, setSearchLoading] = useState(false)
 
-  const debouncedValue = useDebounce(value, 300)
+  const debouncedInputValue = useDebounce(inputValue, searchDebounceMs)
 
   useEffect(() => {
-    selectedIndexRef.current = selectedIndex
-  }, [selectedIndex])
+    if (isSearchMode) {
+      setInputValue(value)
+    } else {
+      const selected = options.find((option) => (option.value ?? option.name) === value)
+      setInputValue(selected?.name ?? "")
+    }
+  }, [value, options, isSearchMode])
 
   const performSearch = useCallback(
     async (query: string) => {
-      if (!onSearch || query.length < 2) {
+      if (!onSearch || query.length < searchMinChars) {
         setSearchResults([])
         return
       }
@@ -184,98 +270,195 @@ export default function BaseSelect({
         setSearchLoading(false)
       }
     },
-    [onSearch],
+    [onSearch, searchMinChars],
   )
 
   useEffect(() => {
-    if (onSearch && show) {
-      performSearch(debouncedValue)
-    }
-  }, [debouncedValue, onSearch, show, performSearch])
+    if (!isSearchMode || !isOpen) return
+    performSearch(debouncedInputValue)
+  }, [debouncedInputValue, isOpen, isSearchMode, performSearch])
 
   const filteredOptions = useMemo(() => {
-    if (onSearch) {
+    if (isSearchMode) {
       if (searchLoading) return []
       return searchResults
     }
-    if (!value) return options
-    const lower = value.toLowerCase()
+    if (!inputValue) return options
+    const lower = inputValue.toLowerCase()
     const exactMatch = options.some((opt) => opt.name.toLowerCase() === lower)
     if (exactMatch) return []
     return options.filter((opt) => opt.name.toLowerCase().includes(lower))
-  }, [onSearch, options, value, searchResults, searchLoading])
+  }, [isSearchMode, options, inputValue, searchResults, searchLoading])
+
+  const selectedIndex = filteredOptions.findIndex(
+    (option) => (option.value ?? option.name) === value,
+  )
+
+  const openListbox = useCallback(() => {
+    setIsOpen(true)
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0)
+  }, [selectedIndex])
+
+  const closeListbox = useCallback(() => {
+    setIsOpen(false)
+    setActiveIndex(-1)
+  }, [])
+
+  const selectOption = useCallback(
+    (option: SelectOption) => {
+      const newValue = option.value ?? option.name
+      onChange(newValue)
+      setInputValue(option.name)
+      closeListbox()
+      inputRef.current?.focus()
+    },
+    [onChange, closeListbox],
+  )
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleClickOutside = (event: globalThis.MouseEvent) => {
+      const target = event.target as Node
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(target) &&
+        !document.getElementById(listboxId)?.contains(target)
+      ) {
+        closeListbox()
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [isOpen, listboxId, closeListbox])
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    setInputValue(newValue)
+    if (!isOpen) openListbox()
+    setActiveIndex(0)
+    if (isSearchMode) {
+      onChange(newValue)
+    }
+  }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (filteredOptions.length === 0) return
-
-    if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+    if (e.altKey && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
       e.preventDefault()
-      setSelectedIndex((prevIndex) => {
-        if (filteredOptions.length === 0) return prevIndex
-        const newIndex =
-          e.key === "ArrowUp"
-            ? (prevIndex - 1 + filteredOptions.length) % filteredOptions.length
-            : (prevIndex + 1) % filteredOptions.length
-        selectedIndexRef.current = newIndex
-        return newIndex
+      if (e.key === "ArrowDown") openListbox()
+      else closeListbox()
+      return
+    }
+
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      if (!isOpen) {
+        openListbox()
+        return
+      }
+      setActiveIndex((prev) => {
+        const max = filteredOptions.length - 1
+        if (max < 0) return -1
+        if (e.key === "ArrowDown") return prev >= max ? 0 : prev + 1
+        return prev <= 0 ? max : prev - 1
       })
+      return
+    }
+
+    if (e.key === "Home" && isOpen) {
+      e.preventDefault()
+      setActiveIndex(0)
+      return
+    }
+
+    if (e.key === "End" && isOpen) {
+      e.preventDefault()
+      setActiveIndex(filteredOptions.length - 1)
+      return
     }
 
     if (e.key === "Enter") {
       e.preventDefault()
-      const selectedOption = filteredOptions[selectedIndexRef.current]
-      if (selectedOption) {
-        onChange(selectedOption.value || selectedOption.name)
-        setShow(false)
+      if (isOpen && activeIndex >= 0 && activeIndex < filteredOptions.length) {
+        selectOption(filteredOptions[activeIndex])
+      } else if (!isOpen) {
+        openListbox()
       }
+      return
     }
 
     if (e.key === "Escape") {
-      setShow(false)
+      e.preventDefault()
+      closeListbox()
     }
   }
 
-  // Surfaced next to the label (not as a dropdown row) when an async search
-  // came back empty, so "no results" reads as field info rather than a fake option.
+  const handleBlur = () => {
+    if (ignoreBlurRef.current) {
+      ignoreBlurRef.current = false
+      inputRef.current?.focus()
+      return
+    }
+    closeListbox()
+    onBlur?.()
+  }
+
+  const handleOptionMouseDown = () => {
+    ignoreBlurRef.current = true
+  }
+
+  const handleFocus = useCallback(() => {
+    openListbox()
+    onFocus?.()
+  }, [openListbox, onFocus])
+
+  const activeOptionId =
+    isOpen && activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+
   const showNoResults =
-    !!onSearch &&
-    show &&
+    isSearchMode &&
+    isOpen &&
     !searchLoading &&
     filteredOptions.length === 0 &&
-    value.length >= 2 &&
+    inputValue.length >= searchMinChars &&
     !!noResultsMessage
 
   return (
-    <InputContainer>
-      <label htmlFor={id || name}>
+    <InputContainer ref={containerRef}>
+      <label htmlFor={inputId}>
         {label}
-        {required && " *"}
-        {errors.length > 0 && <span> {errors.join(", ")}</span>}
-        {showNoResults && <span> {noResultsMessage}</span>}
+        {required ? " *" : null}
+        {errors.length > 0 ? <span> {errors.join(", ")}</span> : null}
+        {showNoResults ? <span> {noResultsMessage}</span> : null}
       </label>
       <input
         {...inputProps}
-        id={id || name}
+        ref={inputRef}
+        id={inputId}
         name={name}
+        role="combobox"
         autoComplete="off"
-        onChange={(e) => onChange(e.target.value)}
-        onBlur={() => {
-          setShow(false)
-          onBlur?.()
-        }}
-        onFocus={() => {
-          setShow(true)
-          onFocus?.()
-        }}
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={activeOptionId}
+        aria-required={required}
+        aria-invalid={errors.length > 0}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        value={value}
+        value={inputValue}
         disabled={disabled}
+        readOnly={disabled}
         required={required}
       />
-      {(loading || searchLoading) && <LoadingCircle />}
+      {loading || searchLoading ? <LoadingCircle /> : null}
       <AnimatePresence>
-        {filteredOptions.length > 0 && show && (
+        {filteredOptions.length > 0 && isOpen ? (
           <m.div
             style={{ zIndex: 1, height: "100%" }}
             initial={{ translateY: "-5px", opacity: 0 }}
@@ -284,15 +467,14 @@ export default function BaseSelect({
           >
             <OptionsList
               options={filteredOptions}
-              onSelect={(selectedValue) => {
-                onChange(selectedValue)
-                setShow(false)
-              }}
+              listboxId={listboxId}
+              activeIndex={activeIndex}
               selectedIndex={selectedIndex}
-              setSelectedIndex={setSelectedIndex}
+              onSelect={selectOption}
+              onMouseDown={handleOptionMouseDown}
             />
           </m.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </InputContainer>
   )

--- a/apps/web/src/components/Forms/Select/Select.styled.tsx
+++ b/apps/web/src/components/Forms/Select/Select.styled.tsx
@@ -13,13 +13,14 @@ export const LoadingCircle = styled.div`
   opacity: 1;
   transition: opacity 250ms;
 `
+
 export const OptionContainer = styled.ul`
   width: 100%;
   border-radius: 5px;
   top: calc(100% + 5px);
   z-index: 1;
   position: absolute;
-  border: 2px solid token(colors.darkGray);
+  border: 2px solid token(colors.border);
   background: token(colors.secondaryBackground);
 
   & > li[data-selected="true"],
@@ -48,4 +49,25 @@ export const OptionContainer = styled.ul`
     position: relative;
     padding: 5px;
   }
+`
+
+export const VirtualizerContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  position: relative;
+`
+
+export const VirtualItem = styled.li`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
+export const NonVirtualItem = styled.li`
+  height: 35px;
+  display: flex;
+  align-items: center;
+  padding: 0 5px;
 `

--- a/apps/web/src/components/Forms/Select/index.tsx
+++ b/apps/web/src/components/Forms/Select/index.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import { useFieldContext } from "@/hooks/form"
-
 import type { SelectFieldProps } from "@/components/Forms/types"
+import { useFieldContext } from "@/hooks/form"
 
 import BaseSelect from "./BaseSelect"
 
@@ -13,6 +12,8 @@ export default function SelectField({
   loading,
   onFocus,
   onSearch,
+  searchDebounceMs,
+  searchMinChars,
   noResultsMessage,
 }: SelectFieldProps) {
   const field = useFieldContext<string>()
@@ -25,10 +26,12 @@ export default function SelectField({
       placeholder={placeholder}
       options={options}
       value={field.state.value ?? ""}
-      onChange={(value) => field.handleChange(value)}
-      onBlur={() => field.handleBlur()}
+      onChange={field.handleChange}
+      onBlur={field.handleBlur}
       onFocus={onFocus}
       onSearch={onSearch}
+      searchDebounceMs={searchDebounceMs}
+      searchMinChars={searchMinChars}
       loading={loading}
       errors={field.state.meta.errors}
       noResultsMessage={noResultsMessage}


### PR DESCRIPTION
## Summary

- Replace `colors.darkGray` with `colors.border` design token in both `Select.styled.tsx`
- Add `SelectPortalContext` to fix option clicks inside Vaul drawers
- Rewrite state model, add full ARIA wiring, extract `OptionsList`, expose configurable search props

## What changed and why

### State model rewrite

The previous implementation tracked the highlighted option through a combination of a `selectedIndex` state and a `selectedIndexRef` — the ref existed solely to work around a stale closure issue on `Enter` keydown. The open/close state lived in a separate `show` boolean, and the raw input value was read directly from the `value` prop, blurring the line between controlled value and transient search text.

All of this has been replaced with three explicit pieces of state: `activeIndex` (the keyboard cursor, -1 when nothing is highlighted), `isOpen`, and `inputValue` (the text currently in the input, independent from the committed `value`). The ref workaround is gone. The keyboard cursor and mouse hover are now fully decoupled — hovering an option no longer moves the cursor, which prevents jarring jumps when the user switches between mouse and keyboard.

### Blur race condition fix

Clicking an option fires `blur` on the input before the `click` on the option registers. The old code worked around this with a `setTimeout(..., 120)` delay on the blur handler — fragile and timing-dependent. The new code sets an `ignoreBlurRef` flag on `mousedown` of the options list (which fires before `blur`) and clears it after the click is processed. The blur handler checks the flag and skips closing the list when it is set. This is deterministic regardless of device speed.

### Full ARIA combobox wiring

The input element now implements the ARIA combobox pattern correctly: `role="combobox"`, `aria-autocomplete="list"`, `aria-haspopup="listbox"`, `aria-expanded` (tied to `isOpen`), `aria-controls` pointing to the listbox, and `aria-activedescendant` tracking the currently highlighted option. `useId` generates stable IDs that are safe for SSR. The options list receives `role="listbox"` and each option gets a stable `id`, `role="option"`, and `aria-selected`. Keyboard scroll-follow is handled by a `useEffect` that calls `scrollIntoView` on the active element whenever `activeIndex` changes.

### `OptionsList` extraction (dashboard)

The options list rendering was previously inlined inside `BaseSelect`. It is now extracted into its own `OptionsList.tsx` file. Along with the extraction, filtering responsibility was moved upstream to `BaseSelect` — `OptionsList` receives an already-filtered array and renders it, rather than receiving the raw search value and filtering internally. A shared `OptionItem` sub-component unifies the virtual (TanStack Virtualizer) and non-virtual rendering paths, eliminating the code duplication between the two branches.

### `SelectPortalContext` (dashboard)

Vaul, the drawer library used in the dashboard, applies `pointer-events: none` to `document.body` when a drawer is open in modal mode. Any React portal that targets `body` — including the select dropdown — becomes non-interactive while the drawer is open, making options unclickable. `SelectPortalContext` is a React context that lets a drawer component provide its own `Drawer.Content` DOM node as the portal target. `BaseSelect` reads from this context: when a container element is provided, the dropdown portals into it (positioned `absolute` relative to the container's bounding rect) instead of targeting `body`. Outside of a drawer the context value is `null` and the original behavior is preserved.

### Configurable search props (web)

`searchDebounceMs` (default `300`) and `searchMinChars` (default `2`) were previously hardcoded inside `BaseSelect`. They are now props, passed through from the form field wrapper in `index.tsx`. This allows individual usages to tune debounce timing and minimum character threshold without touching the component internals.